### PR TITLE
Port Notepad++ "column selection -> multi-editing" so Backspace works on column selections

### DIFF
--- a/scintilla/cocoa/ScintillaView.h
+++ b/scintilla/cocoa/ScintillaView.h
@@ -81,6 +81,13 @@ extern NSString *const SCIUpdateUINotification;
 @property(nonatomic, unsafe_unretained) id<ScintillaNotificationProtocol> delegate;
 @property(nonatomic, readonly) NSScrollView *scrollView;
 
+/// When YES (default), pressing an editing/navigation key (Backspace, arrows,
+/// Home/End, Return) on a column (rectangular) selection first converts it to a
+/// stream multi-selection — matching Notepad++'s "column selection to
+/// multi-editing" behavior, so e.g. Backspace at column 0 joins lines instead
+/// of doing nothing. Wired from the kPrefColumnSel2MultiEdit user default.
+@property(nonatomic) BOOL columnSelToMultiEdit;
+
 + (Class) contentViewClass;
 
 - (void) notify: (NotificationType) type message: (NSString *) message location: (NSPoint) location

--- a/scintilla/cocoa/ScintillaView.mm
+++ b/scintilla/cocoa/ScintillaView.mm
@@ -750,10 +750,64 @@ static NSCursor *cursorFromEnum(Window::Cursor cursor) {
  * handles shortcuts. The input is then forwarded to the Cocoa text input system, which in turn does
  * its own input handling (character composition via NSTextInputClient protocol):
  */
+// LOCAL CHANGE: Notepad++ "column selection to multi-editing" parity.
+//
+// Stock Scintilla refuses to delete a *rectangular* selection across the line
+// start: Editor::DelCharBack forces allowLineStartDeletion = false when
+// sel.IsRectangular(). So Backspace on a zero-width column selection sitting at
+// column 0 does nothing. Notepad++ works around this in its WM_KEYDOWN handler
+// (ScintillaEditView.cpp, setting "_columnSel2MultiEdit", enabled by default):
+// before the key is processed it converts the column selection into a stream
+// multi-selection, after which Backspace joins lines / deletes per caret as
+// users expect.
+//
+// On Windows that handler is naturally skipped while Alt is held, because
+// Alt+key arrives as WM_SYSKEYDOWN — which is what keeps keyboard column
+// extension (Alt+Shift+Arrow) working. macOS delivers Option+key through this
+// same keyDown:, so we must explicitly bypass the conversion while Option (the
+// rectangular-selection modifier, see SCI_SETRECTANGULARSELECTIONMODIFIER) is
+// held, otherwise Option+Shift+Arrow could no longer extend a column block.
+- (void) convertColumnSelectionToMultiEditForKey: (NSEvent *) theEvent {
+	if (!mOwner.columnSelToMultiEdit)
+		return;
+
+	// Leave column-selection extension (Option held) untouched.
+	if ((theEvent.modifierFlags & NSEventModifierFlagOption) != 0)
+		return;
+
+	const long selMode = mOwner.backend->WndProc(Message::GetSelectionMode, 0, 0);
+	if (selMode != static_cast<long>(SelectionMode::Rectangle) &&
+	    selMode != static_cast<long>(SelectionMode::Thin))
+		return;
+
+	switch (theEvent.keyCode) {
+		case 51:  // Backspace (Delete)
+		case 123: // Left
+		case 124: // Right
+		case 125: // Down
+		case 126: // Up
+		case 115: // Home
+		case 119: // End
+		case 36:  // Return
+		case 76:  // keypad Enter
+			break;
+		default:
+			return; // not a key that should collapse the column selection
+	}
+
+	// Switch to stream mode so the key acts on independent carets. The second
+	// call clears the lingering rectangular anchor so subsequent caret movement
+	// stays multi-caret (Neil Hodgson, https://sourceforge.net/p/scintilla/bugs/2412/).
+	mOwner.backend->WndProc(Message::SetSelectionMode, static_cast<uptr_t>(SelectionMode::Stream), 0);
+	mOwner.backend->WndProc(Message::SetSelectionMode, static_cast<uptr_t>(SelectionMode::Stream), 0);
+}
+
 - (void) keyDown: (NSEvent *) theEvent {
 	bool handled = false;
-	if (mMarkedTextRange.length == 0)
+	if (mMarkedTextRange.length == 0) {
+		[self convertColumnSelectionToMultiEditForKey: theEvent];
 		handled = mOwner.backend->KeyboardInput(theEvent);
+	}
 	if (!handled) {
 		NSArray *events = @[theEvent];
 		[self interpretKeyEvents: events];
@@ -1613,6 +1667,8 @@ static NSCursor *cursorFromEnum(Window::Cursor cursor) {
 	if (self) {
 		mContent = [[[[self class] contentViewClass] alloc] initWithFrame: NSZeroRect];
 		mContent.owner = self;
+
+		_columnSelToMultiEdit = YES; // Notepad++ default; overridden from prefs by EditorView
 
 		// Initialize the scrollers but don't show them yet.
 		// Pick an arbitrary size, just to make NSScroller selecting the proper scroller direction

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -2138,6 +2138,12 @@ static int vkToScintillaKey(int vk) {
     [sci message:SCI_SETBACKSPACEUNINDENTS wParam:bsUnindent ? 1 : 0];
     [sci message:SCI_SETTABINDENTS wParam:bsUnindent ? 1 : 0];
 
+    // Notepad++ "column selection to multi-editing": on Backspace/arrows a
+    // column (rectangular) selection is first converted to a stream
+    // multi-selection so the key acts per caret (e.g. Backspace at column 0
+    // joins lines). Handled in SCIContentView keyDown:.
+    sci.columnSelToMultiEdit = [ud boolForKey:kPrefColumnSel2MultiEdit];
+
     BOOL showLineNumbers = [ud boolForKey:kPrefShowLineNumbers];
     [sci message:SCI_SETMARGINWIDTHN wParam:0 lParam:showLineNumbers ? 44 : 0];
 

--- a/src/PreferencesWindowController.h
+++ b/src/PreferencesWindowController.h
@@ -44,6 +44,7 @@ extern NSString *const kPrefTabCloseButton;      // BOOL, default YES
 extern NSString *const kPrefDoubleClickTabClose; // BOOL, default NO
 extern NSString *const kPrefTabBarWrap;          // BOOL, default NO
 extern NSString *const kPrefVirtualSpace;        // BOOL, default NO
+extern NSString *const kPrefColumnSel2MultiEdit; // BOOL, default YES — column selection becomes multi-edit on Backspace/arrows
 extern NSString *const kPrefScrollBeyondLastLine;// BOOL, default NO
 extern NSString *const kPrefScrollSpeedGain;     // double, default 1.0 (1.0 = no mouse-wheel acceleration)
 extern NSString *const kPrefCaretBlinkRate;      // NSInteger ms, default 500

--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -35,6 +35,7 @@ NSString *const kPrefTabCloseButton      = @"tabCloseButton";
 NSString *const kPrefDoubleClickTabClose = @"doubleClickTabClose";
 NSString *const kPrefTabBarWrap          = @"tabBarWrap";
 NSString *const kPrefVirtualSpace        = @"virtualSpace";
+NSString *const kPrefColumnSel2MultiEdit = @"columnSel2MultiEdit";
 NSString *const kPrefScrollBeyondLastLine= @"scrollBeyondLastLine";
 NSString *const kPrefScrollSpeedGain     = @"scrollSpeedGain";
 NSString *const kPrefCaretBlinkRate      = @"caretBlinkRate";
@@ -194,6 +195,7 @@ NSString *const kPrefStyleFontSize      = @"styleFontSize";
         kPrefDoubleClickTabClose:  @NO,
         kPrefTabBarWrap:           @NO,
         kPrefVirtualSpace:         @NO,
+        kPrefColumnSel2MultiEdit:  @YES,
         kPrefScrollBeyondLastLine: @NO,
         kPrefScrollSpeedGain:      @1.0,
         kPrefCaretBlinkRate:       @500,
@@ -808,6 +810,7 @@ NSString *const kPrefStyleFontSize      = @"styleFontSize";
         @[[loc translate:@"Highlight current line"],          @105, kPrefHighlightCurrentLine],
         @[[loc translate:@"Auto-close brackets ( ) [ ] { }"], @700, kPrefAutoCloseBrackets],
         @[[loc translate:@"Enable virtual space"],            @702, kPrefVirtualSpace],
+        @[[loc translate:@"Column selection switches to multi-editing"], @713, kPrefColumnSel2MultiEdit],
         @[[loc translate:@"Scroll beyond last line"],         @703, kPrefScrollBeyondLastLine],
         @[[loc translate:@"Copy/cut line without selection"],  @706, kPrefCopyLineNoSelection],
         @[[loc translate:@"Right-click keeps selection"],      @707, kPrefRightClickKeepsSel],
@@ -2064,6 +2067,7 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
         case 709: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefShowBookmarkMargin]; break;
         case 710: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefShowEOL]; break;
         case 711: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefShowWhitespace]; break;
+        case 713: [ud setBool:[(NSButton *)sender state] == NSControlStateValueOn forKey:kPrefColumnSel2MultiEdit]; break;
         case 712: {  // Line spacing multiplier (issue #149)
             static const double kPresets[5] = {1.0, 1.2, 1.3, 1.4, 1.5};
             NSInteger idx = [(NSPopUpButton *)sender indexOfSelectedItem];


### PR DESCRIPTION
Fixes #164.

## Problem

Backspace on a **zero-width column (rectangular) selection at column 0** is a no-op on macOS; Notepad++ for Windows joins the lines.

The cause is not Scintilla — the bundled engine is byte-identical to Notepad++'s and correctly refuses line-start deletion for *rectangular* selections in `Editor::DelCharBack` (`if (sel.IsRectangular()) allowLineStartDeletion = false;`). Windows works because Notepad++ ports an application-level feature this app was missing.

## Fix

Ports Notepad++'s `_columnSel2MultiEdit` behavior (`PowerEditor/src/ScintillaComponent/ScintillaEditView.cpp`, on by default). In `SCIContentView keyDown:`, a `Rectangle`/`Thin` selection is converted to `SC_SEL_STREAM` (twice, per [Scintilla bug 2412](https://sourceforge.net/p/scintilla/bugs/2412/)) before **Backspace / arrows / Home / End / Return** are forwarded to Scintilla. After conversion the keys act on independent carets, so Backspace joins/deletes as expected.

**macOS-specific subtlety:** on Windows that handler is skipped while Alt is held because `Alt+key` is `WM_SYSKEYDOWN`, which is what preserves keyboard column *extension* (Alt+Shift+Arrow). macOS routes Option+key through the same `keyDown:`, so the conversion is **skipped while Option is held** (Option is the rectangular-selection modifier set via `SCI_SETRECTANGULARSELECTIONMODIFIER`), keeping Option+Shift+Arrow column extension working.

## Changes

- `scintilla/cocoa/ScintillaView.{h,mm}` — `columnSelToMultiEdit` property (default `YES`) and the conversion in `keyDown:`.
- `src/PreferencesWindowController.{h,mm}` — `kPrefColumnSel2MultiEdit` (default `YES`), default registration, and an Editing-page checkbox.
- `src/EditorView.mm` — wires the preference into the view in `applyPreferencesFromDefaults` (updates live).

## Test plan — verified against a local Release build (arm64)

Driven via synthetic input, reading the status bar (`Ln/Col | Length | Lines`) as ground truth:

- [x] Builds clean (`cmake`/`ninja`, and `clang -fsyntax-only`).
- [x] **Zero-width column selection at col 0 + Backspace** → lines join. Length `48 → 44`, Lines `5 → 1`, multiple carets persist at the joins. *(Was a no-op: length stayed `48`.)*
- [x] **Width column selection + Backspace** → block deleted (`HELLO world` ×4 → ` world` ×4, length `48 → 28`).
- [x] **Option+Shift+Arrow** still builds/extends a rectangular column block (conversion skipped while Option held — no regression).
- [x] Preference defaults to on; toggling it off restores stock (rectangular) behavior.

Notes for the reviewer: tested arm64 only (the change has no arch-specific code); the `Thin` selection-mode branch is covered in code but was not exercised interactively.
