### PR TITLE
Find: regex can now match \r\n, \n and \r (#167)

### DIFF
--- a/regex/NppRegexSearch.cxx
+++ b/regex/NppRegexSearch.cxx
@@ -173,6 +173,29 @@ std::regex_constants::match_flag_type MatchFlags(const Document *doc, Sci::Posit
     return fl;
 }
 
+// Search a single [rangeStart, rangeEnd) subrange. Forward keeps the first
+// match, backward keeps the last. Returns false (leaving `out` untouched) for
+// an inverted range — which the per-line clamping below can legitimately
+// produce when the search start sits past a line's content end.
+template<typename Iterator, typename Regex>
+bool MatchInSubrange(const Document *doc, const Regex &regexp,
+                     Sci::Position rangeStart, Sci::Position rangeEnd,
+                     std::regex_constants::match_flag_type fm,
+                     bool forward, std::match_results<Iterator> &out) {
+    if (rangeStart > rangeEnd) return false;   // inverted; zero-width (==) is fine
+    const Iterator itStart(doc, rangeStart);
+    const Iterator itEnd  (doc, rangeEnd);
+    std::regex_iterator<Iterator> it(itStart, itEnd, regexp, fm);
+    const std::regex_iterator<Iterator> last;
+    bool any = false;
+    for (; it != last; ++it) {
+        out = *it;
+        any = true;
+        if (forward) break;   // forward: first match; backward: keep the last
+    }
+    return any;
+}
+
 template<typename Iterator, typename Regex>
 bool FirstMatchOnLines(const Document *doc, const Regex &regexp,
                        const RESearchRange &resr,
@@ -180,23 +203,74 @@ bool FirstMatchOnLines(const Document *doc, const Regex &regexp,
                        std::array<Sci::Position, 10> &bopat,
                        std::array<Sci::Position, 10> &eopat,
                        size_t &nGroups) {
+    const bool forward = resr.increment > 0;
     std::match_results<Iterator> match;
     bool matched = false;
     for (Sci::Line line = resr.lineRangeStart; line != resr.lineRangeBreak; line += resr.increment) {
-        const Sci::Position lineStartPos = doc->LineStart(line);
-        const Sci::Position lineEndPos   = doc->LineEnd(line);
-        const Range lineRange = resr.LineRange(line, lineStartPos, lineEndPos);
-        const Iterator itStart(doc, lineRange.start);
-        const Iterator itEnd  (doc, lineRange.end);
-        const auto fm = MatchFlags(doc, lineRange.start, lineRange.end, lineStartPos, lineEndPos);
-        std::regex_iterator<Iterator> it(itStart, itEnd, regexp, fm);
-        for (const std::regex_iterator<Iterator> last; it != last; ++it) {
-            match = *it;
-            matched = true;
-            if (resr.increment > 0) break;   // forward: first match
-            // backward: keep iterating to find the LAST one in this line
+        const Sci::Position lineStartPos  = doc->LineStart(line);
+        const Sci::Position contentEndPos = doc->LineEnd(line);          // before EOL
+        const Sci::Position termEndPos    = doc->LineStart(line + 1);    // includes EOL
+
+        // Pass 1 — content range. Identical to upstream BuiltinRegex: anchors
+        // ^/$ and word boundaries \b at the true line-content edges (EOL
+        // excluded), so `foo$`, `^foo`, `.$`, `\bword\b` keep matching exactly
+        // as before.
+        const Range contentRange = resr.LineRange(line, lineStartPos, contentEndPos);
+        const auto fmContent = MatchFlags(doc, contentRange.start, contentRange.end,
+                                          lineStartPos, contentEndPos);
+        std::match_results<Iterator> mc;
+        const bool hasC = MatchInSubrange<Iterator>(doc, regexp, contentRange.start,
+                                                    contentRange.end, fmContent, forward, mc);
+
+        // Pass 2 — terminator range. Extends the search to include this line's
+        // EOL bytes so literal \r / \n / \r\n (and patterns running into them,
+        // e.g. `foo\r\n`) can match — exactly what the content-only pass cannot
+        // do, and the root of macOS issue #167. Passing contentEndPos as the
+        // line end makes MatchFlags raise match_not_eol for this pass, so `$`
+        // never matches at the post-EOL range end (the correct `$` always comes
+        // from pass 1). std::regex's multiline mode would obviate the per-line
+        // split but is not honored across the libc++/libstdc++ runtimes this
+        // ships on (see Scintilla's own BuiltinRegex note), so we search per
+        // line and stitch the terminator in here.
+        std::match_results<Iterator> mt;
+        bool hasT = false;
+        const Range termRange = resr.LineRange(line, lineStartPos, termEndPos);
+        if (termRange.end > contentRange.end) {
+            const auto fmTerm = MatchFlags(doc, termRange.start, termRange.end,
+                                           lineStartPos, contentEndPos);
+            hasT = MatchInSubrange<Iterator>(doc, regexp, termRange.start,
+                                             termRange.end, fmTerm, forward, mt);
         }
-        if (matched) break;
+
+        // Reconcile the two candidates by START position: forward keeps the
+        // leftmost, backward the rightmost. On an exact tie the CONTENT match
+        // wins. That tie rule gives a strong guarantee: at every position where
+        // the old content-only search produced a match, this returns the very
+        // same match (same length, same capture groups) — the terminator pass
+        // can only ADD matches at positions the content pass left empty (the
+        // literal \r / \n / \r\n cases of issue #167). It deliberately does not
+        // try to out-rank a content match with a longer terminator-extended one
+        // (e.g. `foo\r?` stays "foo", as it always has): the two passes lose the
+        // pattern's alternation order, so any "longer wins" rule would mis-pick
+        // the branch — and corrupt captures — for patterns that alternate an
+        // anchored branch with an EOL-literal one (`(foo$)|(foo\r\n)`). Matching
+        // a true line terminator inside a single match still requires the
+        // alternative to be unmatchable in the content range, which is exactly
+        // when the content pass is empty and the terminator pass wins outright.
+        if (hasC || hasT) {
+            if (!hasT) {
+                match = mc;
+            } else if (!hasC) {
+                match = mt;
+            } else {
+                const Sci::Position cs = mc[0].first.Pos();
+                const Sci::Position ts = mt[0].first.Pos();
+                const bool pickTerm = forward ? (ts < cs) : (ts > cs);
+                match = pickTerm ? mt : mc;
+            }
+            matched = true;
+            break;
+        }
     }
     if (!matched) return false;
 

--- a/regex/test/run.sh
+++ b/regex/test/run.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Build and run the NppRegexSearch unit harness (regex/test/test_npp_regex.cxx)
+# against the real Scintilla core. No CMake target needed — we compile only the
+# platform-agnostic Scintilla sources that Document depends on, plus the
+# SCI_OWNREGEX backend, and stub out the Platform debug hooks in the test TU.
+#
+# Usage:  bash regex/test/run.sh
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+sci="$root/scintilla"
+out="$(mktemp -d)"
+trap 'rm -rf "$out"' EXIT
+
+# Scintilla core sources required to instantiate and edit a Document.
+core=(Document CellBuffer CharClassify CharacterCategoryMap CharacterType \
+      Decoration PerLine RunStyles UniConversion UniqueString CaseFolder \
+      CaseConvert DBCS RESearch ChangeHistory UndoHistory Geometry)
+srcs=()
+for s in "${core[@]}"; do srcs+=("$sci/src/$s.cxx"); done
+
+clang++ -std=c++17 -stdlib=libc++ \
+    -DSCI_NAMESPACE -DSCI_OWNREGEX -DSCINTILLA_QT=0 \
+    -I"$sci/include" -I"$sci/src" -I"$root/regex" \
+    "$here/test_npp_regex.cxx" "$root/regex/NppRegexSearch.cxx" "${srcs[@]}" \
+    -o "$out/test_npp_regex"
+
+"$out/test_npp_regex"

--- a/regex/test/test_npp_regex.cxx
+++ b/regex/test/test_npp_regex.cxx
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT
+//
+// Standalone unit harness for NppRegexSearch::FindText against a real Scintilla
+// Document. Reproduces macOS issue #167 (regex can't find "\r\n") and guards
+// the ^/$ anchoring + empty-match machinery against regression.
+//
+// Build & run:  regex/test/run.sh   (no CMake target — it links the handful of
+// Scintilla core .cxx files Document needs, plus regex/NppRegexSearch.cxx, into
+// a small self-contained executable). Exits non-zero if any case fails.
+
+// STL first — Scintilla's Document.h/PerLine.h use std::map/forward_list/etc.
+// without including them, expecting the TU to have done so (see NppRegexSearch.cxx).
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <forward_list>
+#include <map>
+#include <memory>
+#include <optional>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "ScintillaTypes.h"
+#include "ILoader.h"
+#include "ILexer.h"
+#include "Debugging.h"
+#include "CharacterType.h"
+#include "CharacterCategoryMap.h"
+#include "Position.h"
+#include "UniqueString.h"
+#include "SplitVector.h"
+#include "Partitioning.h"
+#include "RunStyles.h"
+#include "CellBuffer.h"
+#include "PerLine.h"
+#include "CharClassify.h"
+#include "CaseFolder.h"
+#include "Decoration.h"
+#include "Document.h"
+#include "NppRegexSearch.h"
+
+using namespace Scintilla;
+using namespace Scintilla::Internal;
+
+// Minimal platform-layer stubs so we can link the platform-agnostic Scintilla
+// core without the Cocoa layer.
+namespace Scintilla::Internal::Platform {
+    void DebugPrintf(const char *, ...) noexcept {}
+    void Assert(const char *c, const char *file, int line) noexcept {
+        fprintf(stderr, "Assertion failed: %s at %s:%d\n", c, file, line);
+    }
+}
+
+static int g_fail = 0;
+
+struct Eng {
+    Document doc{DocumentOption::Default};
+    CharClassify cc;
+    RegexSearchBase *re;
+    Eng(const std::string &text) {
+        doc.InsertString(0, text.data(), (Sci::Position)text.size());
+        re = CreateRegexSearch(&cc);
+    }
+    ~Eng() { delete re; }
+    // Forward find from minPos to end.
+    Sci::Position find(const char *pat, Sci::Position minPos, Sci::Position maxPos,
+                       int flags, Sci::Position *len, bool caseSens = true) {
+        return re->FindText(&doc, minPos, maxPos, pat, caseSens, false, false,
+                            static_cast<Scintilla::FindOption>(flags), len);
+    }
+};
+
+static void check(const char *label, bool cond, const std::string &detail = "") {
+    printf("[%s] %s %s\n", cond ? "PASS" : "FAIL", label, detail.c_str());
+    if (!cond) g_fail++;
+}
+
+// Count all forward matches like a Replace-All / Count loop op would.
+static int countAll(const std::string &text, const char *pat, int flags) {
+    Eng e(text);
+    int n = 0;
+    Sci::Position pos = 0, end = (Sci::Position)text.size();
+    for (int guard = 0; guard < 100000; ++guard) {
+        Sci::Position len = 0;
+        Sci::Position p = e.find(pat, pos, end, flags, &len);
+        if (p < 0) break;
+        n++;
+        // advance like a non-replacing loop (Count/MarkAll): step past match,
+        // at least one position to guarantee progress on empty matches.
+        pos = (len > 0) ? p + len : p + 1;
+        if (pos > end) break;
+    }
+    return n;
+}
+
+int main() {
+    const int LOOP  = SCFIND_REGEXP_EMPTYMATCH_NOTAFTERMATCH | SCFIND_REGEXP_SKIPCRLFASONE;
+    const int FINDN = SCFIND_REGEXP_EMPTYMATCH_ALL | SCFIND_REGEXP_SKIPCRLFASONE;
+
+    // ---- Issue #167: literal CRLF -------------------------------------------
+    {
+        std::string t = "alpha\r\nbeta\r\ngamma";   // 2 CRLFs
+        Eng e(t);
+        Sci::Position len = 0;
+        Sci::Position p = e.find("\\r\\n", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("#167 find \\r\\n returns a match", p >= 0,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        check("#167 \\r\\n match has length 2", len == 2, "len=" + std::to_string(len));
+        check("#167 \\r\\n first match at pos 5", p == 5, "pos=" + std::to_string(p));
+        check("#167 count of \\r\\n == 2", countAll(t, "\\r\\n", LOOP) == 2,
+              "got " + std::to_string(countAll(t, "\\r\\n", LOOP)));
+        check("#167 count of \\n == 2", countAll(t, "\\n", LOOP) == 2,
+              "got " + std::to_string(countAll(t, "\\n", LOOP)));
+    }
+
+    // ---- Regression: $ / ^ anchors on a CRLF buffer -------------------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";   // 3 lines
+        // "foo$" should match exactly the "foo" at content end of line 0.
+        Eng e(t);
+        Sci::Position len = 0;
+        Sci::Position p = e.find("foo$", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("foo$ matches at 0 len 3", p == 0 && len == 3,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // "^bar" should match the bar at start of line 1 (pos 5).
+        Sci::Position p2 = e.find("^bar", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("^bar matches at 5 len 3", p2 == 5 && len == 3,
+              "pos=" + std::to_string(p2) + " len=" + std::to_string(len));
+        // Count of "^" should be one per line (3), NOT doubled by CRLF interior.
+        int caretCount = countAll(t, "^", LOOP);
+        check("^ count == 3 (one per line, no CRLF interior over-fire)", caretCount == 3,
+              "got " + std::to_string(caretCount));
+        // Count of "$" should be one per line (3).
+        int dollarCount = countAll(t, "$", LOOP);
+        check("$ count == 3 (one per line, no CRLF interior over-fire)", dollarCount == 3,
+              "got " + std::to_string(dollarCount));
+    }
+
+    // ---- Regression: word search still finds content ------------------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";
+        check("count of \\w+ == 3", countAll(t, "\\w+", LOOP) == 3,
+              "got " + std::to_string(countAll(t, "\\w+", LOOP)));
+        check("literal 'bar' found once", countAll(t, "bar", LOOP) == 1,
+              "got " + std::to_string(countAll(t, "bar", LOOP)));
+    }
+
+    // ---- Regression: empty-match termination on file ending in \n (#151) ----
+    {
+        std::string t = "x\n";
+        // Replace-All-style loop with NOTAFTERMATCH must terminate and not blow
+        // the 100k guard. We just ensure countAll returns a small finite number.
+        int n = countAll(t, "$", LOOP);
+        check("$ on 'x\\n' terminates with small count", n >= 1 && n <= 3,
+              "got " + std::to_string(n));
+    }
+
+    // ---- EOL literal variants & terminator-extending patterns ---------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";
+        Eng e(t);
+        Sci::Position len = 0;
+        // "foo\r\n" should match the whole "foo\r\n" (len 5) at pos 0.
+        Sci::Position p = e.find("foo\\r\\n", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("foo\\r\\n matches at 0 len 5", p == 0 && len == 5,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // "o\r" should match "o\r" (offset 2 len 2).
+        len = 0; p = e.find("o\\r", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("o\\r matches at 2 len 2", p == 2 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // "\r" alone matches at offset 3 len 1.
+        len = 0; p = e.find("\\r", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("\\r matches at 3 len 1", p == 3 && len == 1,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // ".$" matches the last content char before EOL ("o" at offset 2), NOT
+        // anything in the terminator (. excludes line terminators).
+        len = 0; p = e.find(".$", 0, (Sci::Position)t.size(), FINDN, &len);
+        check(".$ matches at 2 len 1", p == 2 && len == 1,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Conservative tie rule: when the content pass already matches at a
+        // position, that match wins unchanged — so `foo\r?` stays "foo" (len 3),
+        // exactly as before the fix. The optional \r is NOT greedily pulled in
+        // (would require knowing the pattern's alternation order; see the long
+        // comment in FirstMatchOnLines). This is not a regression: the old
+        // content-only engine returned "foo" here too.
+        len = 0; p = e.find("foo\\r?", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("foo\\r? stays 'foo' (len 3) — content match preserved", p == 0 && len == 3,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+    }
+
+    // ---- Capture-group integrity --------------------------------------------
+    {
+        // Realistic replace pattern: (\w+) before a CRLF. The content pass cannot
+        // match (needs \r\n), so the terminator pass wins outright and group 1
+        // must capture the word — this is what `\1` in a replacement relies on.
+        std::string t = "foo\r\nbar\r\nbaz";
+        Eng e(t);
+        Sci::Position len = 0;
+        Sci::Position p = e.find("(\\w+)\\r\\n", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("(\\w+)\\r\\n matches foo\\r\\n at 0 len 5", p == 0 && len == 5,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Verify group 1 spans exactly "foo" [0,3) via SubstituteByPosition(\1).
+        std::string repl = "\\1";
+        Sci::Position rlen = (Sci::Position)repl.size();
+        const char *sub = e.re->SubstituteByPosition(&e.doc, repl.data(), &rlen);
+        std::string got(sub, sub + rlen);
+        check("(\\w+)\\r\\n group 1 == 'foo'", got == "foo", "got '" + got + "'");
+    }
+
+    // ---- Anchored-branch-before-EOL-branch alternation ----------------------
+    {
+        // `(foo$)|(foo\r\n)`: a hypothetical correct engine ($ at line-content
+        // end) tries alt 1 first and matches "foo" with group 1 set.
+        // The content pass reproduces exactly that, and the conservative tie rule
+        // keeps it — so group 1 (not group 2) is the one that participates, and
+        // \1/\2 in a replacement stay correct.
+        std::string t = "foo\r\nbar";
+        Eng e(t);
+        Sci::Position len = 0;
+        Sci::Position p = e.find("(foo$)|(foo\\r\\n)", 0, (Sci::Position)t.size(), FINDN, &len);
+        check("(foo$)|(foo\\r\\n) picks alt 1 'foo' (len 3), not the CRLF branch",
+              p == 0 && len == 3, "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        std::string g1 = "\\1", g2 = "\\2";
+        Sci::Position l1 = (Sci::Position)g1.size();
+        const char *s1 = e.re->SubstituteByPosition(&e.doc, g1.data(), &l1);
+        std::string got1(s1, s1 + l1);
+        check("(foo$)|(foo\\r\\n) group 1 == 'foo' (capture not corrupted)",
+              got1 == "foo", "got '" + got1 + "'");
+    }
+
+    // ---- Empty line: CRLF on a blank line is matchable ----------------------
+    {
+        std::string t = "a\r\n\r\nb";   // line1 "a", line2 "" (blank), line3 "b"
+        // count of \r\n == 2
+        check("blank-line buffer: count \\r\\n == 2", countAll(t, "\\r\\n", LOOP) == 2,
+              "got " + std::to_string(countAll(t, "\\r\\n", LOOP)));
+        // ^$ (empty line) should match once (the blank line).
+        check("^$ matches blank line exactly once", countAll(t, "^$", LOOP) == 1,
+              "got " + std::to_string(countAll(t, "^$", LOOP)));
+    }
+
+    // ---- LF-only buffer (Unix EOL) ------------------------------------------
+    {
+        std::string t = "foo\nbar\nbaz";
+        check("LF buffer: count \\n == 2", countAll(t, "\\n", LOOP) == 2,
+              "got " + std::to_string(countAll(t, "\\n", LOOP)));
+        check("LF buffer: foo$ count 1", countAll(t, "foo$", LOOP) == 1,
+              "got " + std::to_string(countAll(t, "foo$", LOOP)));
+        check("LF buffer: ^ count 3", countAll(t, "^", LOOP) == 3,
+              "got " + std::to_string(countAll(t, "^", LOOP)));
+    }
+
+    // ---- Find within a selection that ends mid-line: $ must NOT match -------
+    {
+        std::string t = "foobar";   // single line, no EOL
+        Eng e(t);
+        Sci::Position len = 0;
+        // Search range [0,3): "foo". $ should NOT match at 3 (range truncated
+        // mid-line; not the real line end) -> match_not_eol.
+        Sci::Position p = e.find("foo$", 0, 3, FINDN, &len);
+        check("foo$ does NOT match when range ends mid-line", p < 0,
+              "pos=" + std::to_string(p));
+    }
+
+    // ---- Clean clamp: maxPos before a CRLF (not splitting it) excludes it ----
+    {
+        std::string t = "foobar\r\nx";   // CRLF at 6
+        Eng e(t);
+        Sci::Position len = 0;
+        // [0,6) ends exactly at the \r (pos 6 is a clean boundary, not snapped).
+        // The CRLF is outside the range, so \r\n must NOT be found.
+        Sci::Position p = e.find("\\r\\n", 0, 6, FINDN, &len);
+        check("\\r\\n in [0,6) excludes the CRLF at 6 (no overshoot)", p < 0,
+              "pos=" + std::to_string(p));
+    }
+
+    // ---- Backward search (Find Previous) ------------------------------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";   // CRLFs at 3 and 8
+        Eng e(t);
+        Sci::Position len = 0;
+        // Backward find of \r\n from end: minPos>maxPos signals reverse.
+        Sci::Position p = e.find("\\r\\n", (Sci::Position)t.size(), 0, FINDN, &len);
+        check("backward \\r\\n finds LAST one at 8", p == 8 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Backward find of "bar".
+        len = 0; p = e.find("bar", (Sci::Position)t.size(), 0, FINDN, &len);
+        check("backward 'bar' at 5", p == 5 && len == 3,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Backward find of foo$ -> matches foo at 0.
+        len = 0; p = e.find("foo$", (Sci::Position)t.size(), 0, FINDN, &len);
+        check("backward foo$ at 0", p == 0 && len == 3,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+    }
+
+    // ---- UTF-8 path (multibyte content + CRLF) ------------------------------
+    {
+        // "héllo\r\nwörld"  (é, ö are 2-byte UTF-8). Bytes:
+        // h(1) é(2) l l o = 6 bytes content, then \r\n, then w ö r l d.
+        std::string t = "h\xC3\xA9llo\r\nw\xC3\xB6rld";
+        Document doc{DocumentOption::Default};
+        doc.SetDBCSCodePage(65001);   // SC_CP_UTF8 -> exercises UTF8Iterator path
+        doc.InsertString(0, t.data(), (Sci::Position)t.size());
+        CharClassify cc; RegexSearchBase *re = CreateRegexSearch(&cc);
+        Sci::Position len = 0;
+        Sci::Position crlf = (Sci::Position)t.find('\r');
+        Sci::Position p = re->FindText(&doc, 0, (Sci::Position)t.size(), "\\r\\n",
+                                       true, false, false,
+                                       static_cast<Scintilla::FindOption>(FINDN), &len);
+        check("UTF-8: \\r\\n found at the CRLF byte offset", p == crlf && len == 2,
+              "pos=" + std::to_string(p) + " expected=" + std::to_string(crlf) +
+              " len=" + std::to_string(len));
+        // Anchored match still works on the UTF-8 path.
+        len = 0;
+        p = re->FindText(&doc, 0, (Sci::Position)t.size(), "llo$", true, false, false,
+                         static_cast<Scintilla::FindOption>(FINDN), &len);
+        check("UTF-8: llo$ matches end of first line", p == crlf - 3 && len == 3,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        delete re;
+    }
+
+    // ---- Selection-clamped ranges (Find in Selection) ----------------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";   // CRLFs at 3 and 8
+        Eng e(t);
+        Sci::Position len = 0;
+        // Forward search restricted to [0,8): should find the FIRST \r\n (at 3)
+        // and must NOT reach the second CRLF at 8 (outside the range).
+        Sci::Position p = e.find("\\r\\n", 0, 8, FINDN, &len);
+        check("clamped fwd \\r\\n in [0,8) finds 3", p == 3 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // A maxPos that falls BETWEEN \r and \n (here 4) is snapped outward to 5
+        // by Scintilla's RESearchRange (MovePositionOutsideChar with checkLineEnd
+        // — it never splits a CRLF pair). So the effective range is [0,5) and
+        // \r\n legitimately matches at 3. This is pre-existing Scintilla behavior
+        // shared with upstream BuiltinRegex, documented here so it isn't mistaken
+        // for an out-of-bounds overshoot.
+        len = 0; p = e.find("\\r\\n", 0, 4, FINDN, &len);
+        check("fwd \\r\\n with maxPos splitting CRLF snaps to [0,5), matches 3",
+              p == 3 && len == 2, "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        len = 0; p = e.find("\\r\\n", 6, (Sci::Position)t.size(), FINDN, &len);
+        check("clamped fwd \\r\\n from mid-line 6 finds 8", p == 8 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+    }
+
+    // ---- Backward search with clamped ranges --------------------------------
+    {
+        std::string t = "foo\r\nbar\r\nbaz";
+        Eng e(t);
+        Sci::Position len = 0;
+        // Backward within [10..3] (start high=10, end low=3): the only \r\n fully
+        // inside is at 3 (the one at 8 is inside too). Rightmost is 8.
+        Sci::Position p = e.find("\\r\\n", 10, 3, FINDN, &len);
+        check("clamped bwd \\r\\n in (3,10] finds rightmost 8", p == 8 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Backward starting from 7 (mid second 'bar' line, before the 2nd CRLF):
+        // rightmost \r\n at or below start is the first one at 3.
+        len = 0; p = e.find("\\r\\n", 7, 0, FINDN, &len);
+        check("clamped bwd \\r\\n from 7 finds 3", p == 3 && len == 2,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+        // Backward find of \n.
+        len = 0; p = e.find("\\n", (Sci::Position)t.size(), 0, FINDN, &len);
+        check("bwd \\n finds rightmost at 9", p == 9 && len == 1,
+              "pos=" + std::to_string(p) + " len=" + std::to_string(len));
+    }
+
+    printf("\n%s (%d failure%s)\n", g_fail ? "FAILURES" : "ALL PASS",
+           g_fail, g_fail == 1 ? "" : "s");
+    return g_fail ? 1 : 0;
+}


### PR DESCRIPTION
## Problem (#167)

With **Regular expression** enabled, Find could not match `\r\n` (nor `\n` or `\r`) — it reported *"Find: Can't find the text"*.

**Root cause:** the `std::regex` backend (`regex/NppRegexSearch.cxx`) searches the document one line at a time over `[LineStart(line), LineEnd(line)]`, and `LineEnd()` points *before* the line's EOL bytes (`CellBuffer::LineEnd` backs up over CR/LF). So the `\r\n` bytes were never inside any searched range and could not match. This mirrors Scintilla's `BuiltinRegex` limitation; Notepad++ on Windows avoids it by using Boost.Regex over the whole buffer.

## Fix

`FirstMatchOnLines` now does two passes per line:

1. **Content range** `[lineStart, LineEnd]` — unchanged. Keeps `^`/`$`/`\b` anchored at the true line-content edges, so `foo$`, `^foo`, `.$`, `\bword\b` behave exactly as before.
2. **Terminator range** `[lineStart, LineStart(line+1)]` — includes the EOL bytes, so `\r`, `\n`, `\r\n` (and patterns running into them, e.g. `foo\r\n`, `\r\n|\r|\n`) can match. `match_not_eol` is set for this pass (via the existing `MatchFlags`, by passing the content end as the line end), so `$` never matches at the post-EOL boundary — the correct `$` always comes from pass 1.

The two candidates are reconciled by **start position** (forward = leftmost, backward = rightmost); on an exact tie the **content match wins**.

### Why content-wins-ties

It gives a strong backward-compat guarantee: *at every position where the old content-only search produced a match, FindText returns the identical match — same length, same capture groups.* The terminator pass can only **add** matches at positions the content pass left empty. This deliberately avoids a "longer wins" rule, which would mis-pick the branch (and corrupt `\1`/`\2` in replace) for a pattern that alternates an anchored branch with an EOL-literal one, e.g. `(foo$)|(foo\r\n)` — the two passes can't see the pattern's alternation order.

### Why still per-line (no multiline)

`std::regex`'s `multiline` mode would let `^`/`$` work over the whole buffer, but it is not honored consistently across the libc++/libstdc++ runtimes this ships on (see the note in Scintilla's own `Document.cxx` `MatchOnLines`). On older runtimes the flag is ignored, which would silently break `foo$` on CRLF files. So per-line iteration is kept and the terminator is stitched in.

### Known limitation

A greedy quantifier is **not** pulled into the EOL when a content match already exists at that start (e.g. `foo\r?` stays `"foo"`) — this matches the pre-fix behavior, so it is not a regression. Fully general cross-line / alternation-order-correct matching would require Boost.Regex (as on Windows) or reliable `multiline`.

## Tests

Adds a standalone unit harness, `regex/test/test_npp_regex.cxx` + `regex/test/run.sh`, that drives `NppRegexSearch::FindText` against a real Scintilla `Document` (no CMake target needed). **40 cases, all passing**, covering:

- the bug: `\r\n`, `\n`, `\r`, `foo\r\n`, `o\r`, `(\w+)\r\n`, blank-line CRLF
- anchor regression guards: `^`/`$` counts on CRLF (no interior over-fire), `.$`, `^$`, `\w+`, LF-only buffers, mid-line-truncated ranges
- empty-match termination (`$` on a file ending in `\n` — the #151 guard)
- capture-group integrity: `(\w+)\r\n` and `(foo$)|(foo\r\n)` keep the correct participating group
- backward (Find Previous) and selection-clamped sub-ranges
- the UTF-8 (`UTF8Iterator`) path

```
bash regex/test/run.sh
```

Verified the `scintilla` static library (which compiles `NppRegexSearch.cxx`) still builds for `arm64;x86_64`.
