### PR TITLE
Fix #214: add "Don't Save All" button when closing multiple unsaved tabs

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -1937,6 +1937,7 @@ static void _nppTahoeRoundEditorCard(NSView *container, NSView *content) {
      NSMenuDelegate>
 - (void)_saveOpenSidePanels;
 - (void)_populatePluginOverflowMenu:(NSMenu *)menu;  // plugins overflow (≫) submenu
+- (void)_closeEditors:(NSArray<EditorView *> *)editors inManager:(TabManager *)mgr;
 @end
 
 // Lazy delegate for the plugins overflow (≫) submenu: on open it asks the window
@@ -4842,8 +4843,7 @@ static void removeMacroFromShortcutsXML(NSString *name) {
 }
 
 - (void)closeAllTabs:(id)sender {
-    for (EditorView *ed in _tabManager.allEditors.copy)
-        [_tabManager closeEditor:ed];
+    [self _closeEditors:_tabManager.allEditors.copy inManager:_tabManager];
 }
 
 - (void)printDocument:(id)sender {
@@ -8376,44 +8376,88 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
 
 #pragma mark - File: Close Multiple Documents
 
-/// Prompt to save a modified editor synchronously. Returns YES if safe to close.
-- (BOOL)_promptSaveBeforeClose:(EditorView *)ed {
-    if (!ed.isModified) return YES;
+/// Outcome of prompting whether to save one modified editor while closing a
+/// batch of tabs (Close All, Close All But This, …).
+typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
+    NppBatchCloseSaveAttempted, ///< User chose Save; editor is clean iff the save succeeded.
+    NppBatchCloseDiscard,       ///< Discard this document's changes.
+    NppBatchCloseDiscardAll,    ///< Discard this and every remaining modified document.
+    NppBatchCloseCancel,        ///< Abort the whole batch close; leave remaining tabs open.
+};
+
+/// Prompt to save one modified editor. When `allowAll` is YES the alert offers
+/// an extra "Don't Save All" button so the user can discard every remaining
+/// unsaved document in the batch with a single click (issue #214).
+- (NppBatchCloseDecision)_promptBatchSaveBeforeClose:(EditorView *)ed allowAll:(BOOL)allowAll {
+    NppLocalizer *loc = [NppLocalizer shared];
     NSAlert *alert = [[NSAlert alloc] init];
-    alert.messageText = [NSString stringWithFormat:[[NppLocalizer shared] translate:@"Save '%@' before closing?"], ed.displayName];
-    [alert addButtonWithTitle:[[NppLocalizer shared] translate:@"Save"]];
-    [alert addButtonWithTitle:[[NppLocalizer shared] translate:@"Don't Save"]];
-    [alert addButtonWithTitle:[[NppLocalizer shared] translate:@"Cancel"]];
+    alert.messageText = [NSString stringWithFormat:[loc translate:@"Save '%@' before closing?"], ed.displayName];
+    [alert addButtonWithTitle:[loc translate:@"Save"]];        // NSAlertFirstButtonReturn
+    [alert addButtonWithTitle:[loc translate:@"Don't Save"]];  // NSAlertSecondButtonReturn
+    if (allowAll)
+        [alert addButtonWithTitle:[loc translate:@"Don't Save All"]]; // NSAlertThirdButtonReturn
+    [alert addButtonWithTitle:[loc translate:@"Cancel"]];      // Third (or fourth) button
+
     NSModalResponse r = [alert runModal];
-    if (r == NSAlertThirdButtonReturn) return NO;  // Cancel
     if (r == NSAlertFirstButtonReturn) {            // Save
         if (ed.filePath) {
             NSError *err;
-            return [ed saveError:&err];
+            [ed saveError:&err];                    // on failure the editor stays modified
+        } else {
+            // Untitled — run modal save panel. Backing out leaves it modified.
+            NSSavePanel *sp = [NSSavePanel savePanel];
+            sp.nameFieldStringValue = ed.displayName;
+            if ([sp runModal] == NSModalResponseOK) {
+                NSError *err;
+                [ed saveToPath:sp.URL.path error:&err];
+            }
         }
-        // Untitled — run modal save panel
-        NSSavePanel *sp = [NSSavePanel savePanel];
-        sp.nameFieldStringValue = ed.displayName;
-        if ([sp runModal] == NSModalResponseOK) {
-            NSError *err;
-            return [ed saveToPath:sp.URL.path error:&err];
-        }
-        return NO;
+        return NppBatchCloseSaveAttempted;
     }
-    return YES; // Don't Save
+    if (r == NSAlertSecondButtonReturn) return NppBatchCloseDiscard;                   // Don't Save
+    if (allowAll && r == NSAlertThirdButtonReturn) return NppBatchCloseDiscardAll;     // Don't Save All
+    return NppBatchCloseCancel;                                                        // Cancel
+}
+
+/// Close every editor in `editors` (all belonging to `mgr`), prompting once per
+/// modified document. "Don't Save All" suppresses the prompt for the remaining
+/// modified documents; Cancel aborts the batch and leaves the unprocessed tabs
+/// open. A modified document whose save failed or was declined is kept open and
+/// the batch continues with the next tab.
+- (void)_closeEditors:(NSArray<EditorView *> *)editors inManager:(TabManager *)mgr {
+    NSUInteger dirtyCount = 0;
+    for (EditorView *ed in editors)
+        if (ed.isModified && !ed.cloneSibling) dirtyCount++;
+    BOOL allowAll = dirtyCount > 1;
+
+    BOOL discardAll = NO;
+    for (EditorView *ed in editors) {
+        if (ed.isModified && !ed.cloneSibling && !discardAll) {
+            switch ([self _promptBatchSaveBeforeClose:ed allowAll:allowAll]) {
+                case NppBatchCloseCancel:     return;            // abort the whole batch
+                case NppBatchCloseDiscardAll: discardAll = YES; break;
+                case NppBatchCloseSaveAttempted:
+                    if (ed.isModified) continue;                 // save failed/declined — keep this tab
+                    break;
+                case NppBatchCloseDiscard:    break;
+            }
+        }
+        [mgr removeEditor:ed];
+    }
+    [self updateTitle];
 }
 
 - (void)closeAllButCurrent:(id)sender {
     EditorView *current = [self currentEditor];
     NSArray *all = _activeTabManager.allEditors.copy;
+    NSMutableArray<EditorView *> *toClose = [NSMutableArray array];
     for (NSInteger i = 0; i < (NSInteger)all.count; i++) {
         EditorView *ed = all[i];
         if (ed == current) continue;
         if ([_activeTabManager.tabBar isTabPinnedAtIndex:i]) continue;
-        if ([self _promptSaveBeforeClose:ed])
-            [_activeTabManager closeEditor:ed];
+        [toClose addObject:ed];
     }
-    [self updateTitle];
+    [self _closeEditors:toClose inManager:_activeTabManager];
 }
 
 - (void)closeAllToLeft:(id)sender {
@@ -8421,13 +8465,12 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     NSArray *all = _activeTabManager.allEditors;
     NSInteger idx = [all indexOfObject:current];
     if (idx == NSNotFound) return;
-    for (NSInteger i = idx - 1; i >= 0; i--) {
+    NSMutableArray<EditorView *> *toClose = [NSMutableArray array];
+    for (NSInteger i = 0; i < idx; i++) {
         if ([_activeTabManager.tabBar isTabPinnedAtIndex:i]) continue;
-        EditorView *ed = all[i];
-        if ([self _promptSaveBeforeClose:ed])
-            [_activeTabManager closeEditor:ed];
+        [toClose addObject:all[i]];
     }
-    [self updateTitle];
+    [self _closeEditors:toClose inManager:_activeTabManager];
 }
 
 - (void)closeAllToRight:(id)sender {
@@ -8435,35 +8478,38 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     NSArray *all = _activeTabManager.allEditors;
     NSInteger idx = [all indexOfObject:current];
     if (idx == NSNotFound) return;
-    for (NSInteger i = (NSInteger)all.count - 1; i > idx; i--) {
+    NSMutableArray<EditorView *> *toClose = [NSMutableArray array];
+    for (NSInteger i = idx + 1; i < (NSInteger)all.count; i++) {
         if ([_activeTabManager.tabBar isTabPinnedAtIndex:i]) continue;
-        EditorView *ed = all[i];
-        if ([self _promptSaveBeforeClose:ed])
-            [_activeTabManager closeEditor:ed];
+        [toClose addObject:all[i]];
     }
-    [self updateTitle];
+    [self _closeEditors:toClose inManager:_activeTabManager];
 }
 
 - (void)closeAllUnchanged:(id)sender {
+    // Collect against the stable snapshot first: removing tabs mid-loop would
+    // shift the live tab-bar indices out from under isTabPinnedAtIndex:.
     NSArray *all = _activeTabManager.allEditors.copy;
+    NSMutableArray<EditorView *> *toClose = [NSMutableArray array];
     for (NSInteger i = 0; i < (NSInteger)all.count; i++) {
         EditorView *ed = all[i];
         if (ed.isModified) continue;
         if ([_activeTabManager.tabBar isTabPinnedAtIndex:i]) continue;
-        [_activeTabManager closeEditor:ed];
+        [toClose addObject:ed];
     }
+    for (EditorView *ed in toClose)
+        [_activeTabManager removeEditor:ed];  // unmodified — no prompt needed
     [self updateTitle];
 }
 
 - (void)closeAllButPinned:(id)sender {
     NSArray *all = _activeTabManager.allEditors.copy;
+    NSMutableArray<EditorView *> *toClose = [NSMutableArray array];
     for (NSInteger i = 0; i < (NSInteger)all.count; i++) {
         if ([_activeTabManager.tabBar isTabPinnedAtIndex:i]) continue;
-        EditorView *ed = all[i];
-        if ([self _promptSaveBeforeClose:ed])
-            [_activeTabManager closeEditor:ed];
+        [toClose addObject:all[i]];
     }
-    [self updateTitle];
+    [self _closeEditors:toClose inManager:_activeTabManager];
 }
 
 #pragma mark - Edit: Column Mode / Character Panel / Brace Select

--- a/src/TabManager.h
+++ b/src/TabManager.h
@@ -39,6 +39,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Close a specific editor tab.
 - (void)closeEditor:(EditorView *)editor;
 
+/// Close a specific editor tab WITHOUT any save prompt. The caller is
+/// responsible for having already handled unsaved changes. Keeps at least one
+/// tab open (opens a fresh untitled tab if this was the last one).
+- (void)removeEditor:(EditorView *)editor;
+
 /// Remove an editor from this manager without any save prompt or deallocation.
 /// The EditorView stays alive; caller is responsible for adopting it elsewhere.
 - (void)evictEditor:(EditorView *)editor;


### PR DESCRIPTION
Fixes #214.

### Problem
Closing several unsaved tabs (Close All, Close All But This, …) forced the user to click **Don't Save** once for every document.

### Change
Adds a **Don't Save All** button to the save-confirmation dialog shown while closing a batch of tabs. Clicking it discards every remaining unsaved document in one click. The button only appears when the batch has more than one unsaved document.

All batch-close actions now share one helper:
- `_promptBatchSaveBeforeClose:allowAll:` — shows **Save / Don't Save / Don't Save All / Cancel**.
- `_closeEditors:inManager:` — prompts once per modified doc, suppresses the prompt for the rest after **Don't Save All**, aborts on **Cancel**, and keeps a tab open if its save failed or was declined.
- `closeAllTabs:`, `closeAllButCurrent:`, `closeAllToLeft:`, `closeAllToRight:`, `closeAllButPinned:` route through it.

### Drive-by fixes in the same code path
- **Double-prompt:** the old loops called `_promptSaveBeforeClose:` and then `closeEditor:`, which prompted a second time on "Don't Save".
- **Shifting tab-bar indices:** pinned state was queried against the live tab bar while tabs were removed mid-loop; all batch ops (incl. `closeAllUnchanged:`) now snapshot the close list first.
- Exposed `TabManager removeEditor:` as the non-prompting close primitive.

### Notes
- "Close All" previously used `TabManager`'s separate hardcoded-English dialog; it now uses the same localized prompt as the other batch ops. The new "Don't Save All" string falls back to English where untranslated.
- **Cancel** now aborts the whole batch (was: skip one doc) — conventional behavior that pairs with "Don't Save All".

### Testing
Builds clean (ad-hoc signed). Reviewed for NSAlert button-return mapping (3- vs 4-button), clone-sibling handling, and save-failure/panel-cancel paths.
