### PR TITLE
Fix silent data loss when a save fails (close tab / Save All)

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -4817,13 +4817,20 @@ static void removeMacroFromShortcutsXML(NSString *name) {
     // Save all modified files silently. Named files save to disk;
     // untitled files prompt Save As for each one.
     NSArray<TabManager *> *managers = @[_tabManager, _subTabManagerH, _subTabManagerV];
+    NSMutableArray<NSString *> *failures = [NSMutableArray array];
     for (TabManager *mgr in managers) {
         for (EditorView *ed in mgr.allEditors.copy) {
             if (!ed.isModified) continue;
             if (ed.filePath) {
                 NSError *err;
-                [ed saveError:&err];
+                // Don't silently swallow a failed write: the tab stays dirty but
+                // the user is told "Save All" succeeded. Collect failures and
+                // surface them, matching saveDocument:'s alert-on-failure.
+                if (![ed saveError:&err])
+                    [failures addObject:[NSString stringWithFormat:@"%@ — %@",
+                        ed.displayName, err.localizedDescription ?: @"save failed"]];
             } else {
+                // runSavePanelForEditor: surfaces its own error on failure.
                 [mgr runSavePanelForEditor:ed completion:nil];
             }
         }
@@ -4832,6 +4839,12 @@ static void removeMacroFromShortcutsXML(NSString *name) {
     [self updateTitle];
     if (_docListPanel && [_sidePanelHost hasPanel:_docListPanel])
         [_docListPanel refreshModifiedStates];
+    if (failures.count) {
+        NSAlert *alert = [[NSAlert alloc] init];
+        alert.messageText = [[NppLocalizer shared] translate:@"Some documents could not be saved"];
+        alert.informativeText = [failures componentsJoinedByString:@"\n"];
+        [alert runModal];
+    }
 }
 
 - (void)closeCurrentTab:(id)sender {

--- a/src/TabManager.mm
+++ b/src/TabManager.mm
@@ -136,7 +136,14 @@
                 return;
             }
             NSError *err;
-            [editor saveError:&err];
+            if (![editor saveError:&err]) {
+                // Save failed (read-only path, full disk, encoding-inapplicable, …).
+                // Surface the error and KEEP the tab — falling through to
+                // removeEditor: would silently destroy the user's unsaved changes
+                // even though they explicitly chose "Save".
+                [[NSAlert alertWithError:err] runModal];
+                return;
+            }
         } else if (resp == NSAlertThirdButtonReturn) {
             return;
         }
@@ -336,9 +343,13 @@
     [panel beginWithCompletionHandler:^(NSModalResponse result) {
         if (result == NSModalResponseOK) {
             NSError *err;
-            [editor saveToPath:panel.URL.path error:&err];
+            // Report the ACTUAL write result, not just that the panel was
+            // confirmed. completion(YES) tells the close path it may discard the
+            // buffer, so reporting success on a failed write loses the content.
+            BOOL saved = [editor saveToPath:panel.URL.path error:&err];
+            if (!saved) [[NSAlert alertWithError:err] runModal];
             [self refreshAllTabTitles];
-            if (completion) completion(YES);
+            if (completion) completion(saved);
         } else {
             if (completion) completion(NO);
         }


### PR DESCRIPTION
### Problem
Three save paths treated a **failed** save as success and could silently discard the user's unsaved content. Each was independently confirmed by two reviewers (an adversarial verifier and a second model).

1. **`TabManager closeEditor:` (named file)** — the **Save** button on the unsaved-changes alert called `saveError:` but ignored the result, then removed the tab unconditionally. A failed write (read-only path, full disk, encoding-inapplicable, disconnected volume) destroyed the edits with no warning.
2. **`TabManager runSavePanelForEditor:`** — reported `completion(YES)` whenever the save panel was *confirmed*, regardless of whether `saveToPath:` actually wrote. The untitled close path then removed the tab on a failed write, losing the typed content.
3. **`saveAllDocuments:`** — swallowed per-file save errors, so the user was told "Save All" succeeded while a file silently failed to write.

### Fix
- #1: alert on failure and **keep the tab open** (return before `removeEditor:`).
- #2: report the **real** `saveToPath:` result to the completion block and alert on failure, so the close path keeps the tab.
- #3: collect failed saves and surface them in one alert.

All three mirror the alert-on-failure pattern the project already uses in `saveDocument:` / `saveDocumentAs:`.

### Repro (bug #1)
Open a saved file, edit it, make the file/parent dir unwritable (`chmod`), close the tab, click **Save**. Before: tab closes, edits gone, no error. After: error shown, tab stays open.

### Notes
- No buffer is discarded on failure (`saveToPath:` returns before clearing `_isModified`, so the tab stays dirty).
- No double-alert: `saveAllDocuments:` routes untitled docs through `runSavePanelForEditor:` (which now alerts itself); named-file failures use the aggregate alert.

### Testing
Builds clean (ad-hoc signed). Fixes reviewed for the success path (still closes on a successful save), single-invocation of the completion block (OK-success / OK-failure / cancel), nil-safety, and no other callers depending on the old always-`YES` behavior.
