### PR TITLE
Fix "Save a Copy As" rebinding the document to the copy

### DIFF
--- a/src/EditorView.h
+++ b/src/EditorView.h
@@ -92,6 +92,10 @@ extern NSNotificationName const EditorViewDidSaveNotification;
 /// Save to a specific path.
 - (BOOL)saveToPath:(NSString *)path error:(NSError **)error;
 
+/// Write a snapshot of the current content to a path WITHOUT changing which
+/// file this editor is bound to ("Save a Copy As"). Returns YES on success.
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error;
+
 /// Set the syntax language by name (e.g. "cpp", "python"). Pass "" for plain text.
 - (void)setLanguage:(NSString *)languageName;
 

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -697,7 +697,11 @@ static NSUInteger nppLargeFileThreshold(void) {
     return [self saveToPath:_filePath error:error];
 }
 
-- (BOOL)saveToPath:(NSString *)path error:(NSError **)error {
+/// Encode the current document (honouring its encoding/BOM) and write the bytes
+/// to `path`. Pure I/O: does NOT change the editor's identity (file path,
+/// modified state, save point, backup, clone links, language). Returns NO and
+/// sets *error on failure.
+- (BOOL)_writeContentsToPath:(NSString *)path error:(NSError **)error {
     BOOL ok = NO;
 
     if (_fileEncoding == NSUTF8StringEncoding) {
@@ -767,6 +771,19 @@ static NSUInteger nppLargeFileThreshold(void) {
                                                code:NSFileWriteUnknownError userInfo:nil];
         return NO;
     }
+    return YES;
+}
+
+/// Write a snapshot of the current contents to `path` WITHOUT repointing the
+/// editor at it. Used by "Save a Copy As": the live document keeps its original
+/// file, modified state, save point and backup, so subsequent saves still go to
+/// the original. Returns NO and sets *error on failure.
+- (BOOL)writeCopyToPath:(NSString *)path error:(NSError **)error {
+    return [self _writeContentsToPath:path error:error];
+}
+
+- (BOOL)saveToPath:(NSString *)path error:(NSError **)error {
+    if (![self _writeContentsToPath:path error:error]) return NO;
 
     NSString *oldPath = _filePath;
     _filePath = [path copy];

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -8250,7 +8250,10 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     [panel beginSheetModalForWindow:self.window completionHandler:^(NSModalResponse r) {
         if (r != NSModalResponseOK) return;
         NSError *err;
-        if (![ed saveToPath:panel.URL.path error:&err])
+        // "Save a Copy As" writes a snapshot but must NOT repoint the live
+        // document at the copy — otherwise future saves/edits would go to the
+        // copy and the original would be stranded.
+        if (![ed writeCopyToPath:panel.URL.path error:&err])
             [[NSAlert alertWithError:err] beginSheetModalForWindow:self.window completionHandler:nil];
     }];
 }


### PR DESCRIPTION
### Problem
**"Save a Copy As"** (`saveDocumentCopyAs:`) wrote the copy via `saveToPath:error:` — the full *Save As* implementation. On a successful write that method **rebinds the editor's identity** to the new path: sets `_filePath`, clears the modified flag and save point, deletes the original's backup, syncs the clone sibling's path, records the copy's mtime, and re-detects language.

So after "Save a Copy As", the live buffer was bound to the **copy**:
- a subsequent ⌘S (or further edits) went to the copy, not the original;
- the original's pending edits were no longer tracked as modified;
- the original's backup was deleted.

That's the opposite of the command's defining behavior — a copy must be a side snapshot that leaves the document associated with its **original** file. (Confirmed independently by two reviewers.)

### Fix
Split the byte-encode-and-write half of `saveToPath:error:` into a private `_writeContentsToPath:error:` helper, add a public `writeCopyToPath:error:` that performs **only** the write (no identity rebind), and point `saveDocumentCopyAs:` at it.

`saveToPath:error:` is behavior-preserving — it now calls the helper, then runs the identical rebind tail on success.

### Repro
Open `~/orig.txt`, edit it, **File → Save a Copy As → `~/copy.txt`**. Before: the tab is now `copy.txt`, no longer dirty; ⌘S overwrites the copy and `orig.txt` never gets the edits. After: the tab stays `orig.txt` (still dirty), the copy is written, ⌘S saves to `orig.txt`.

### Testing
Builds clean (ad-hoc signed). Reviewed that the write logic (UTF-8 zero-copy, BOM, UTF-16, inapplicable-encoding early return, write-failure error) and the full rebind tail are preserved exactly in `saveToPath:`, that `writeCopyToPath:` mutates none of the editor's identity/state, and that no other `saveToPath:` caller is affected.
