### PR TITLE
Fix two window-controller leaks (scroll-sync timer, new-window observer)

### DIFF
--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -299,12 +299,24 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
 
     [mwc showWindow:nil];
 
-    // Observe close to remove from our array
-    [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification
-                                                      object:mwc.window
-                                                       queue:nil
-                                                  usingBlock:^(NSNotification *note) {
+    // Observe close to remove from our array. Keep the returned token and
+    // remove the observer when it fires — otherwise the notification center
+    // retains the block (which strongly captures mwc) for the app's lifetime,
+    // leaking every opened-and-closed secondary window's controller and its
+    // whole object graph.
+    __block id closeToken =
+        [[NSNotificationCenter defaultCenter] addObserverForName:NSWindowWillCloseNotification
+                                                          object:mwc.window
+                                                           queue:nil
+                                                      usingBlock:^(NSNotification *note) {
         [self.windowControllers removeObject:mwc];
+        [[NSNotificationCenter defaultCenter] removeObserver:closeToken];
+        // Also drop the __block storage's strong ref to the token, otherwise
+        // token -> block -> __block storage -> token stays a retained island
+        // (which captures mwc) even after the center deregisters it. The center
+        // retains the block across this in-flight post, so it is safe to release
+        // our last ref here. (Bug B leak fix.)
+        closeToken = nil;
     }];
 
     return mwc;

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -2185,6 +2185,12 @@ static void _nppTahoeRoundEditorCard(NSView *container, NSView *content) {
         [NSEvent removeMonitor:_scrollZoomEventMonitor];
         _scrollZoomEventMonitor = nil;
     }
+    // Defensive: windowWillClose: already tears these down, but invalidate here
+    // too in case the controller is released without a window-close notification.
+    [_scrollSyncTimer invalidate];
+    _scrollSyncTimer = nil;
+    [_autoSaveTimer invalidate];
+    _autoSaveTimer = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -10614,6 +10620,12 @@ static int64_t _sysctlInt(const char *name) {
 - (void)windowWillClose:(NSNotification *)n {
     [_autoSaveTimer invalidate];
     _autoSaveTimer = nil;
+    // The scroll-sync timer also targets self with repeats:YES; if a split with
+    // sync scrolling is active it would otherwise retain this controller forever
+    // (run-loop keeps the timer alive) and keep polling the closed window's
+    // editors. Mirror the _autoSaveTimer teardown above.
+    [_scrollSyncTimer invalidate];
+    _scrollSyncTimer = nil;
     [self saveWindowFrame];
     // Note: session already saved in windowShouldClose:
 


### PR DESCRIPTION
Fixes two window-controller leaks found in the bug hunt (each confirmed by two independent reviewers).

### A) `_scrollSyncTimer` never invalidated on window close
`_scrollSyncTimer` is a repeating `NSTimer` targeting `self`, scheduled on the run loop. It was invalidated only when the sync-scrolling toggles were turned **off** — never on window close. So closing a window that had synchronized split-scrolling active left the timer **retaining the controller for the rest of the session**, firing ~60×/s against the closed window's editors. The sibling `_autoSaveTimer` was already invalidated in `windowWillClose:`; this just does the same for `_scrollSyncTimer` (plus a defensive invalidate in `dealloc`).

### B) New-window close observer leaks its controller
`openNewWindow` registered a block-based `NSWindowWillCloseNotification` observer but **discarded the returned token**. The notification center retains the block, which strongly captures the new `MainWindowController`, so **every opened-and-closed secondary window leaked its controller and entire object graph** for the app's lifetime.

The block now keeps the token and, when it fires, removes the observer **and nils the captured token**. The `nil` is required: without it, `token → block → __block storage → token` remains a retained island (capturing `mwc`) even after the center deregisters — a subtlety caught during review. The center retains the block across the in-flight post, so releasing our last ref inside the block is safe.

### Testing
Builds clean (ad-hoc signed). Reviewed: timer invalidation is idempotent (no use-after-free, dealloc double-invalidate safe); the timer was the blocking retain so the controller can now dealloc; the observer block still removes `mwc` from `windowControllers` before deregistering; primary window unaffected (it never had this observer).
