### PR TITLE
Fix #226 indentation preferences not persisting on close

### DIFF
--- a/src/PreferencesWindowController.mm
+++ b/src/PreferencesWindowController.mm
@@ -1309,6 +1309,15 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
 
     [v addSubview:optBox];
 
+    // [Default] is selected initially — hide "Use default value" checkbox and
+    // enable controls. The table selection delegate may not fire during page
+    // construction because the view isn't yet in a window.
+    defaultChk.hidden = YES;
+    sizeField.enabled = YES;
+    tabRadio.enabled = YES;
+    spaceRadio.enabled = YES;
+    bsChk.enabled = YES;
+
     // ── Auto-indent radio group (right of Indent Settings) ──
     NSBox *autoBox = [[NSBox alloc] initWithFrame:NSMakeRect(215, y - 90, 160, 100)];
     autoBox.title = [loc translate:@"Auto-indent"];
@@ -2487,6 +2496,7 @@ static NSDictionary<NSString *, NSString *> *_langDisplayNames() {
 
 - (void)closePrefs:(id)sender {
     [self _saveClickableSchemes];
+    [self.window makeFirstResponder:nil]; // commit any in-progress text field edits
     [self.window orderOut:nil];
 }
 


### PR DESCRIPTION
When editing the indent size on the Indentation preferences page and clicking Close, the new value was silently discarded because the text field's action (prefChanged:) only fires on Return or end-editing and the window closed before the field could commit.

Additionally, the "Use default value" checkbox was incorrectly shown (and indent controls were disabled) when [Default] was selected, because the initial selectRowIndexes: during page construction fires the table delegate before the view is in a window, causing the tag-based view lookup to fail silently.

Changes:

- closePrefs: call [self.window makeFirstResponder:nil] before orderOut: to flush any uncommitted text field edits. This also benefits every other text-field-based preference (caret blink rate, edge column, etc.).

- _buildIndentationPage: after building the options box, explicitly set the correct initial state for the [Default] selection — hide the checkbox and enable the indent controls — rather than relying on the delegate callback which cannot find the controls during construction.

Tested on MacOS Tahoe 26.5.1, M4 Air.