### PR TITLE
Fix data loss when a save fails on tab close

### DIFF
--- a/src/TabManager.mm
+++ b/src/TabManager.mm
@@ -135,8 +135,11 @@
                 }];
                 return;
             }
-            NSError *err;
-            [editor saveError:&err];
+            NSError *err = nil;
+            if (![editor saveError:&err]) {
+                if (err) [[NSAlert alertWithError:err] runModal];
+                return;   // save failed — keep the tab (and its changes) open
+            }
         } else if (resp == NSAlertThirdButtonReturn) {
             return;
         }
@@ -335,10 +338,11 @@
     panel.nameFieldStringValue = editor.displayName;
     [panel beginWithCompletionHandler:^(NSModalResponse result) {
         if (result == NSModalResponseOK) {
-            NSError *err;
-            [editor saveToPath:panel.URL.path error:&err];
+            NSError *err = nil;
+            BOOL ok = [editor saveToPath:panel.URL.path error:&err];
+            if (!ok && err) [[NSAlert alertWithError:err] runModal];
             [self refreshAllTabTitles];
-            if (completion) completion(YES);
+            if (completion) completion(ok);
         } else {
             if (completion) completion(NO);
         }


### PR DESCRIPTION
## Problem
`TabManager closeEditor:` prompts to save a modified file on close, but on the **named-file** path it calls `[editor saveError:&err]` and ignores the result, then falls through to `removeEditor:` unconditionally. If the write fails (read-only file, no permission, disk full, removable volume gone), the tab — and the unsaved changes — are destroyed with **no error shown**.

The **untitled** path has the same gap: `runSavePanelForEditor:completion:` ignores `saveToPath:error:` and always calls `completion(YES)`, so the caller removes the buffer even when the write failed.

This is the single-tab sibling of the close-all path hardened in #217 (which keeps a tab open when its save fails).

## Impact
User hits Cmd-W / the tab's close button on a modified file, picks **Save**, the save silently fails, and the document closes with all changes lost.

## Fix
- Named path: keep the tab open and surface the error when `saveError:` returns `NO`.
- Untitled path: propagate the real `saveToPath:error:` result through `completion`, alerting on failure.

## Verification
Builds clean (ninja). Logic mirrors the existing hardened close-all flow in `MainWindowController`.
