### PR TITLE
Fix heap overflow and dropped single-char selection in -selectedText

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -4715,9 +4715,13 @@ static NSSet<NSString *> *_cLikeLanguages() {
 
 /// Get selected text as NSString. Returns nil if no selection.
 - (nullable NSString *)selectedText {
+    // SCI_GETSELTEXT returns the selection length in bytes WITHOUT the NUL,
+    // but writes a terminating NUL one byte past that length — so the buffer
+    // must be len + 1 bytes (len == 1 is a real single-character selection).
     sptr_t len = [_scintillaView message:SCI_GETSELTEXT wParam:0 lParam:0];
-    if (len <= 1) return nil; // no selection (len includes NUL)
-    char *buf = (char *)malloc((size_t)len);
+    if (len <= 0) return nil; // no selection
+    char *buf = (char *)malloc((size_t)len + 1);
+    if (!buf) return nil;
     [_scintillaView message:SCI_GETSELTEXT wParam:0 lParam:(sptr_t)buf];
     NSString *s = [NSString stringWithUTF8String:buf] ?: @"";
     free(buf);


### PR DESCRIPTION
## Problem
`-[EditorView selectedText]` sizes its buffer at `malloc(len)` where `len = SCI_GETSELTEXT(0, NULL)`. In the bundled Scintilla, `SCI_GETSELTEXT` returns the selection length in bytes **excluding** the terminating NUL (`Editor.cxx` `GetSelText`: `memcpy(ptr, …, Length()); ptr[Length()] = '\0'; return Length();`), so the handler writes `len + 1` bytes into a `len`-byte allocation — a **1-byte heap overflow on every selection retrieval** (hashing, case conversion, base64, copy helpers, …).

The guard `if (len <= 1) return nil` also discards a legitimate **single-character** selection (`len == 1`).

## Fix
- `malloc(len + 1)` (room for the NUL Scintilla writes), matching the documented `1 + SCI_GETSELTEXT(0,NULL)` buffer rule and the Cocoa `ScintillaView.mm` convention.
- Guard on `len <= 0`, so one-character selections work.
- Bail on `malloc` failure.

## Verification
Builds clean (ninja). Scintilla semantics confirmed against `scintilla/src/Editor.cxx` and `scintilla/doc/ScintillaDoc.html`.
