### PR TITLE
Fix Sort Lines / Remove Duplicates truncating non-ASCII text

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -4853,8 +4853,11 @@ static NSSet<NSString *> *_cLikeLanguages() {
     [_scintillaView message:SCI_BEGINUNDOACTION];
     [_scintillaView message:SCI_SETTARGETSTART wParam:(uptr_t)start];
     [_scintillaView message:SCI_SETTARGETEND   wParam:(uptr_t)end];
-    [_scintillaView message:SCI_REPLACETARGET  wParam:(uptr_t)joined.length
-                                               lParam:(sptr_t)joined.UTF8String];
+    // SCI_REPLACETARGET wParam is a BYTE count — use the UTF-8 byte length, not
+    // joined.length (UTF-16 units), or non-ASCII content gets truncated.
+    const char *joinedUTF8 = joined.UTF8String;
+    [_scintillaView message:SCI_REPLACETARGET  wParam:(uptr_t)strlen(joinedUTF8)
+                                               lParam:(sptr_t)joinedUTF8];
     [_scintillaView message:SCI_ENDUNDOACTION];
 }
 


### PR DESCRIPTION
## Problem
`-[EditorView applySortedLines:…]` passes `joined.length` as the `SCI_REPLACETARGET` length. `NSString.length` is **UTF-16 code units**, but `SCI_REPLACETARGET`'s `wParam` is a **byte count**. For any line containing multibyte UTF-8 (accents, CJK, emoji) the byte length exceeds the UTF-16 count, so Scintilla copies too few bytes and **drops the tail** of the replacement block.

## Impact
Sort Lines (all variants) and Remove Duplicate Lines silently lose characters from the end of the affected region whenever the text contains non-ASCII.

## Fix
Use `strlen(joined.UTF8String)` as the byte count, matching the sibling helper `_setLineText:`.

## Verification
Builds clean (ninja). `SCI_REPLACETARGET` byte-count semantics confirmed against `scintilla/src/Editor.cxx` (`std::string_view(CharPtrFromSPtr(lParam), wParam)`) and `ScintillaDoc.html`.
