### PR TITLE
fix: File name should be constant (#250)

### DIFF
--- a/src/TabManager.mm
+++ b/src/TabManager.mm
@@ -76,15 +76,6 @@
     EditorView *editor = [[EditorView alloc] initWithFrame:_contentView.bounds];
     editor.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
-    // Mirrors NPP: reuse the lowest available untitled index rather than always incrementing.
-    // e.g. if "new 1" and "new 3" are open, next tab is "new 2" (fills the gap).
-    NSMutableSet<NSNumber *> *used = [NSMutableSet set];
-    for (EditorView *ed in _editors)
-        if (!ed.filePath) [used addObject:@(ed.untitledIndex)];
-    NSInteger idx = 1;
-    while ([used containsObject:@(idx)]) idx++;
-    [editor restoreUntitledIndex:idx];
-
     [self insertEditor:editor title:editor.displayName modified:NO];
     return editor;
 }


### PR DESCRIPTION
### Problem
When creating new unsaved tabs, the editor assigns names like "new 1", "new 2", etc. If a user saved or closed "new 12" and then created a new tab, the editor would recycle "new 12" instead of moving forward to "new 14".

This happened because TabManager.addNewTab scanned open tabs for the lowest unused index, filling gaps left by saved/closed tabs.

### Fix
Removed the 8-line gap-filling scan in TabManager.addNewTab. The existing monotonic static counter in EditorView.mm (_untitledCounter) already assigns strictly increasing indices on construction — the gap-filling code was overriding it via restoreUntitledIndex:.

**This change is consistent with Windows Notepad++ behavior, which also uses a persistent counter and does not recycle indices.**

**Tested on MacOS Tahoe 26.5.1, M4 chip computer.**