### PR TITLE
Fix stray 'u' breaking compilation of AppDelegate.mm

### DIFF
--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -872,7 +872,7 @@ static NSString *const kUpdateMenuItemTag = @"checkForUpdatesMenuItem";
                                            assets:json[@"assets"]];
                 }
             } else {
-u                // Up to date — leave the menu item plain (no badge / icon).
+                // Up to date — leave the menu item plain (no badge / icon).
                 NSMenuItem *mi = [self _updateMenuItem];
                 if (mi) {
                     mi.title = @"Check for Updates…";


### PR DESCRIPTION
### Problem
`src/AppDelegate.mm` does not compile. A stray `u` token was left before the comment in the up-to-date branch of `-checkForUpdateUserInitiated:`:

```objc
} else {
u                // Up to date — leave the menu item plain (no badge / icon).
    NSMenuItem *mi = [self _updateMenuItem];
```

Because it precedes `//`, the `u` is code, not a comment. It parses as a bare identifier immediately followed by the `NSMenuItem *mi` declaration — a hard ObjC++ syntax error, so `AppDelegate.mm` (and therefore the whole app) fails to build.

It was introduced in `b2a4c36`, a fat-finger while editing that very comment.

### Fix
Remove the stray `u`. One-character change; no behavior change.
