### PR TITLE
Fix Git panel unable to stage/open files with non-ASCII names

### DIFF
--- a/src/GitHelper.mm
+++ b/src/GitHelper.mm
@@ -86,7 +86,10 @@
 }
 
 + (NSArray<NSDictionary<NSString *, NSString *> *> *)statusAtRoot:(NSString *)root {
-    NSString *out = [self _run:@[@"status", @"--porcelain", @"-u"] dir:root];
+    // core.quotePath=false makes git emit non-ASCII paths as raw UTF-8 instead
+    // of C-quoting them (e.g. "café.txt" rather than "\"caf\303\251.txt\""),
+    // so substringFromIndex:3 yields a usable pathspec for add/diff/open.
+    NSString *out = [self _run:@[@"-c", @"core.quotePath=false", @"status", @"--porcelain", @"-u"] dir:root];
     NSMutableArray *items = [NSMutableArray array];
     for (NSString *line in [out componentsSeparatedByString:@"\n"]) {
         if (line.length < 4) continue;


### PR DESCRIPTION
### Problem
Files with non-ASCII names cannot be staged, unstaged, diffed, or opened from the Git panel.

`git status --porcelain` C-quotes non-ASCII paths under git's default `core.quotePath=true`. A file named `café.txt` comes back as:

```
?? "caf\303\251.txt"
```

`statusAtRoot:` takes `substringFromIndex:3` and stores that quoted, octal-escaped string verbatim as the path. Downstream, `git add -- "\"caf\303\251.txt\""` matches nothing, `diffForFile:` shows nothing, and the on-disk open path is wrong. Since `stageFile:`/`unstageFile:` ignore git's exit status and always call `cb(YES)`, the panel reports success while doing nothing — so every internationally-named file is silently unstageable.

### Fix
Invoke `git -c core.quotePath=false status --porcelain -u`, so git emits raw UTF-8 paths:

```
?? café.txt
```

`substringFromIndex:3` now yields `café.txt`, a valid pathspec for `add`/`restore`/`diff`/open.

### Verification
Reproduced in a scratch repo containing `café.txt`: default output was `?? "caf\303\251.txt"`; with the flag it is `?? café.txt`, and `git add -- café.txt` then stages the file (rc=0). ASCII paths and `old -> new` rename parsing are unaffected.
