### PR TITLE
Fix whole-document Sort Lines corrupting newline-terminated files

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -4844,6 +4844,15 @@ static NSSet<NSString *> *_cLikeLanguages() {
     } else {
         lineStart = 0;
         lineEnd   = [sci message:SCI_GETLINECOUNT] - 1;
+        // GETLINECOUNT includes the phantom empty line after a trailing EOL.
+        // Excluding it keeps a whole-document sort from floating a blank line
+        // to the top and from swallowing the file's final newline (the range
+        // then stops at the end of the last content line, before that EOL).
+        if (lineEnd > lineStart) {
+            sptr_t lastStart = [sci message:SCI_POSITIONFROMLINE   wParam:(uptr_t)lineEnd];
+            sptr_t lastEnd   = [sci message:SCI_GETLINEENDPOSITION wParam:(uptr_t)lineEnd];
+            if (lastEnd == lastStart) lineEnd--;
+        }
     }
 
     *startPos = [sci message:SCI_POSITIONFROMLINE wParam:(uptr_t)lineStart];


### PR DESCRIPTION
### Problem
Running **Sort Lines** (or Remove Duplicate Lines) with **no selection** corrupts almost any newline-terminated file: it inserts a blank line at the top and deletes the file's final newline.

Cause: with no selection, `linesForSortingStartPos:endPos:` sets the last line to `SCI_GETLINECOUNT - 1`. In Scintilla that index is the *phantom* empty line that exists after a trailing EOL. So the whole-document sort:
1. collects an empty `""` element, which an ascending sort floats to the top, and
2. drops the trailing newline — the replaced range extends to the end of that phantom line, but the rejoined text has no trailing EOL.

Example (Sort Lines Ascending, no selection):
```
b␊         →    ␊
a␊              a␊
                b
```
i.e. `"b\na\n"` becomes `"\na\nb"`.

### Fix
When there is no selection and the last line is empty (`SCI_POSITIONFROMLINE(lineEnd) == SCI_GETLINEENDPOSITION(lineEnd)`), exclude it. The sort range then stops at the end of the last content line, so the final newline is left untouched and no blank line is introduced.

### Verification (traced case-by-case)
| Input | Result |
|-------|--------|
| `"b\na\n"` (trailing EOL) | `"a\nb\n"` |
| `"b\na"` (no trailing EOL) | `"a\nb"` |
| `""` (empty doc) | `""`, no crash |
| `"b\n"` (single line) | `"b\n"` |

Files without a trailing newline and the empty document are unaffected; `GETLINECOUNT == 1` skips the decrement branch (no off-by-one).
