### PR TITLE
Remove duplicate "Hide" item from the App menu

### DIFF
--- a/src/MenuBuilder.mm
+++ b/src/MenuBuilder.mm
@@ -136,7 +136,6 @@ static NSMenu *buildLanguageMenu() {
         ? @"Settings…" : @"Preferences…";
     [appMenu addItem:item(prefsTitle, @selector(showPreferences:), @",")];
     addSep(appMenu);
-    [appMenu addItemWithTitle:@"Hide Notepad++" action:@selector(hide:) keyEquivalent:@"h"];
     [appMenu addItemWithTitle:@"Hide Nextpad++" action:@selector(hide:) keyEquivalent:@"h"];
     NSMenuItem *hideOthers = [appMenu addItemWithTitle:@"Hide Others" action:@selector(hideOtherApplications:) keyEquivalent:@"h"];
     hideOthers.keyEquivalentModifierMask = NSEventModifierFlagCommand | NSEventModifierFlagOption;


### PR DESCRIPTION
### Problem
The App menu shows **two** Hide items:

```objc
[appMenu addItemWithTitle:@"Hide Notepad++" action:@selector(hide:) keyEquivalent:@"h"];
[appMenu addItemWithTitle:@"Hide Nextpad++" action:@selector(hide:) keyEquivalent:@"h"];
```

Both are wired to `hide:` with the same ⌘H — a merge artifact where the HIG-menu branch kept the old `Notepad++` line while `main`'s rebrand added the `Nextpad++` one. AppKit resolves the shared key equivalent to the first item, so "Hide Nextpad++"'s ⌘H never fires; it's a visible dead duplicate, and it leaks the stale "Notepad++" brand into an otherwise "Nextpad++" menu.

### Fix
Delete the stale `Hide Notepad++` line, leaving a single correctly-branded `Hide Nextpad++`. `Hide Others` (⌘⌥H) and `Show All` are unchanged.
