### PR TITLE
Report Git stage and unstage failures

### DIFF
--- a/src/GitHelper.h
+++ b/src/GitHelper.h
@@ -21,10 +21,12 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSString *)diffForFile:(NSString *)path root:(NSString *)root;
 
 /// Stage a file (git add). Calls completion on main queue.
-+ (void)stageFile:(NSString *)path root:(NSString *)root completion:(void (^)(BOOL success))cb;
++ (void)stageFile:(NSString *)path root:(NSString *)root
+       completion:(void (^)(BOOL success, NSString *_Nullable error))cb;
 
 /// Unstage a file (git restore --staged). Calls completion on main queue.
-+ (void)unstageFile:(NSString *)path root:(NSString *)root completion:(void (^)(BOOL success))cb;
++ (void)unstageFile:(NSString *)path root:(NSString *)root
+         completion:(void (^)(BOOL success, NSString *_Nullable error))cb;
 
 /// Commit with message. Calls completion(success, errorMessage) on main queue.
 + (void)commitMessage:(NSString *)msg root:(NSString *)root

--- a/src/GitHelper.mm
+++ b/src/GitHelper.mm
@@ -2,9 +2,12 @@
 
 @implementation GitHelper
 
-// ── Private: run git synchronously, return stdout string ─────────────────────
+// ── Private: run git synchronously and capture both output streams ───────────
 
-+ (NSString *)_run:(NSArray<NSString *> *)args dir:(NSString *)dir {
++ (BOOL)_run:(NSArray<NSString *> *)args
+         dir:(NSString *)dir
+      output:(NSString *_Nullable *_Nullable)output
+ errorOutput:(NSString *_Nullable *_Nullable)errorOutput {
     NSTask *task = [[NSTask alloc] init];
     task.launchPath = @"/usr/bin/git";
     task.arguments = args;
@@ -15,22 +18,35 @@
     task.standardError  = errPipe;
     @try {
         [task launch];
-    } @catch (NSException *) {
-        return @"";
+    } @catch (NSException *exception) {
+        if (output) *output = @"";
+        if (errorOutput) *errorOutput = exception.reason ?: @"Failed to launch git";
+        return NO;
     }
     // Drain stdout and stderr concurrently while git runs. Each pipe buffer is
     // only ~64KB; if either fills, git blocks on write and never exits — and
     // reading just one stream before waitUntilExit still deadlocks on the other.
     NSFileHandle *errFH = errPipe.fileHandleForReading;
+    __block NSData *errData = nil;
     dispatch_semaphore_t errDone = dispatch_semaphore_create(0);
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        [errFH readDataToEndOfFile];
+        errData = [errFH readDataToEndOfFile];
         dispatch_semaphore_signal(errDone);
     });
     NSData *data = [outPipe.fileHandleForReading readDataToEndOfFile];
     [task waitUntilExit];
     dispatch_semaphore_wait(errDone, DISPATCH_TIME_FOREVER);
-    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"";
+    if (output)
+        *output = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: @"";
+    if (errorOutput)
+        *errorOutput = [[NSString alloc] initWithData:errData encoding:NSUTF8StringEncoding] ?: @"";
+    return task.terminationStatus == 0;
+}
+
++ (NSString *)_run:(NSArray<NSString *> *)args dir:(NSString *)dir {
+    NSString *output = nil;
+    [self _run:args dir:dir output:&output errorOutput:nil];
+    return output ?: @"";
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -110,17 +126,22 @@
     return result.length ? result : nil;
 }
 
-+ (void)stageFile:(NSString *)path root:(NSString *)root completion:(void (^)(BOOL))cb {
++ (void)stageFile:(NSString *)path root:(NSString *)root
+       completion:(void (^)(BOOL, NSString *_Nullable))cb {
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        [self _run:@[@"add", @"--", path] dir:root];
-        dispatch_async(dispatch_get_main_queue(), ^{ if (cb) cb(YES); });
+        NSString *error = nil;
+        BOOL success = [self _run:@[@"add", @"--", path] dir:root output:nil errorOutput:&error];
+        dispatch_async(dispatch_get_main_queue(), ^{ if (cb) cb(success, success ? nil : error); });
     });
 }
 
-+ (void)unstageFile:(NSString *)path root:(NSString *)root completion:(void (^)(BOOL))cb {
++ (void)unstageFile:(NSString *)path root:(NSString *)root
+         completion:(void (^)(BOOL, NSString *_Nullable))cb {
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
-        [self _run:@[@"restore", @"--staged", @"--", path] dir:root];
-        dispatch_async(dispatch_get_main_queue(), ^{ if (cb) cb(YES); });
+        NSString *error = nil;
+        BOOL success = [self _run:@[@"restore", @"--staged", @"--", path]
+                                dir:root output:nil errorOutput:&error];
+        dispatch_async(dispatch_get_main_queue(), ^{ if (cb) cb(success, success ? nil : error); });
     });
 }
 

--- a/src/GitPanel.mm
+++ b/src/GitPanel.mm
@@ -550,18 +550,32 @@ static NSString * const kLastRepoRootKey = @"GitPanelLastRepoRoot";
     return _items[row];
 }
 
+- (void)_showGitFailure:(NSString *)title error:(nullable NSString *)error {
+    NSAlert *alert = [[NSAlert alloc] init];
+    alert.alertStyle = NSAlertStyleWarning;
+    alert.messageText = [[NppLocalizer shared] translate:title];
+    alert.informativeText = error.length ? error : [[NppLocalizer shared] translate:@"Unknown error"];
+    [alert runModal];
+}
+
 - (void)_stageSelected:(id)sender {
     _GitStatusItem *it = [self _itemAtClickedRow];
     if (!it || !_repoRoot) return;
     NSString *root = _repoRoot, *path = it.path;
-    [GitHelper stageFile:path root:root completion:^(BOOL ok) { [self refresh]; }];
+    [GitHelper stageFile:path root:root completion:^(BOOL ok, NSString *error) {
+        if (!ok) [self _showGitFailure:@"Stage Failed" error:error];
+        [self refresh];
+    }];
 }
 
 - (void)_unstageSelected:(id)sender {
     _GitStatusItem *it = [self _itemAtClickedRow];
     if (!it || !_repoRoot) return;
     NSString *root = _repoRoot, *path = it.path;
-    [GitHelper unstageFile:path root:root completion:^(BOOL ok) { [self refresh]; }];
+    [GitHelper unstageFile:path root:root completion:^(BOOL ok, NSString *error) {
+        if (!ok) [self _showGitFailure:@"Unstage Failed" error:error];
+        [self refresh];
+    }];
 }
 
 - (void)_openSelected:(id)sender {


### PR DESCRIPTION
Make Git panel stage and unstage operations reflect the real Git result instead of always reporting success internally.

- return termination status and stderr from the shared deadlock-safe Git runner
- propagate stage and unstage failures on the main queue
- show actionable Git errors in the panel
- preserve existing read-only Git helper behavior

Validation:
- changed Objective-C++ sources compile successfully
- git diff --check passes
- Claude Sonnet 5 independently reviewed the final diff and returned APPROVE
- full bundle packaging reaches the existing Spotlight/codesign failure (-10822) on this machine