### PR TITLE
fix: closing modal dialogs via close button no longer freezes the app

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -5054,7 +5054,17 @@ static void removeMacroFromShortcutsXML(NSString *name) {
     btnCancel.action = @selector(abortModal);
     [cv addSubview:btnCancel];
 
+    // clicking the red x doesn't call stopModal/abortModal on its own — the
+    // window vanishes but the modal loop keeps running, swallowing every click.
+    // basically the app looks frozen. lets catch that close and treat it as cancel.
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp abortModal]; }];
+
     NSModalResponse resp = [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
     [panel orderOut:nil];
     if (resp != NSModalResponseStop) return;
 
@@ -5378,7 +5388,16 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     // Initial check (also sets btnOK.enabled to its starting state)
     checkConflict();
 
+    // same deal as the run-macro dialog — red x needs to end the modal session
+    // or the app goes into a ghost-modal state where nothing is clickable (#283)
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp abortModal]; }];
+
     NSModalResponse resp = [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
     [panel orderOut:nil];
     if (resp != NSModalResponseStop) return;
 
@@ -6239,7 +6258,15 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     tv.doubleAction = @selector(activatePressed:);
     tv.target = helper;
 
+    // without this the close button (red x) leaves us stuck in modal limbo
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp stopModal]; }];
+
     [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
 }
 
 #pragma mark - UI Validation
@@ -9245,7 +9272,15 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
     // Initial check (also sets btnOK.enabled to its starting state)
     checkConflict();
 
+    // red x = cancel, not "leave the app in purgatory"
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp abortModal]; }];
+
     NSModalResponse resp = [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
     [panel orderOut:nil];
     if (resp != NSModalResponseStop || !nameField.stringValue.length) return;
 
@@ -10406,7 +10441,15 @@ static BOOL _writeCLIScript(NSString *script, NSString *path, NSError **outErr) 
     objc_setAssociatedObject(panel, "realDS", realDS, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     [tv reloadData];
 
+    // the x button doesn't end the modal on its own, so we do it ourselves
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp stopModal]; }];
+
     [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
 }
 
 #pragma mark - Help / Debug

--- a/src/ShortcutMapperWindowController.mm
+++ b/src/ShortcutMapperWindowController.mm
@@ -1096,7 +1096,16 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     // Initial check (also sets btnOK.enabled to its starting state)
     checkConflict();
 
+    // handle the window close button (red x) — without this the modal session
+    // outlives the panel and the app becomes unclickable (#283)
+    id closeObserver = [[NSNotificationCenter defaultCenter]
+        addObserverForName:NSWindowWillCloseNotification
+                    object:panel
+                     queue:nil
+                usingBlock:^(NSNotification *note) { [NSApp abortModal]; }];
+
     NSModalResponse resp = [NSApp runModalForWindow:panel];
+    [[NSNotificationCenter defaultCenter] removeObserver:closeObserver];
     [panel orderOut:nil];
     if (resp != NSModalResponseStop) return;
 


### PR DESCRIPTION
## fixes #283

### the problem

clicking the close button (red x) on modal panels doesn't call `stopModal`/`abortModal` — the window disappears but `NSApp` stays stuck in its modal run loop, swallowing every mouse click. the app looks completely frozen. keyboard still works, but nothing is clickable. only way out is force quit.

### root cause

`[NSApp runModalForWindow:]` enters a modal loop that can only be exited by calling `stopModal` or `abortModal`. the Run/Cancel buttons wire these correctly, but the window's close button (red x) bypasses them entirely. the window closes visually, but the modal session lives on invisibly.

### the fix

added `NSWindowWillCloseNotification` observers to all 6 affected closable modal dialogs — same pattern already used by the CLI Usage panel in the same file (so this isn't new, just wasn't applied everywhere):

- **Run Macro Multiple Times** — the one reported in #283
- **Save Macro (Shortcut)**
- **Windows List** 
- **Run Cmd → Save Shortcut**
- **Macro Manager**
- **Shortcut Mapper → Modify**

dialogs with OK/Cancel use `abortModal` (X = Cancel). dialogs with only Done/Close use `stopModal`.

### files changed

- `src/MainWindowController.mm` — 5 dialogs fixed
- `src/ShortcutMapperWindowController.mm` — 1 dialog fixed

### testing

- builds clean (only pre-existing deprecation warnings)
- tested: open Run Macro Multiple Times → close with red X → app stays responsive ✓
- tested: Cancel and Run buttons still work as before ✓