### PR TITLE
Fix multi-window quit discarding secondary windows' tabs and backups

### DIFF
--- a/src/AppDelegate.h
+++ b/src/AppDelegate.h
@@ -17,6 +17,11 @@
 /// Launch timestamp for -loadingTime display.
 @property (nonatomic, strong, nullable) NSDate *launchStart;
 
+/// YES once -applicationShouldTerminate: has begun tearing windows down.
+/// Windows consult this so they don't re-save the session per-window while the
+/// app is quitting — that save has already happened once, for all windows.
+@property (nonatomic, readonly) BOOL isTerminating;
+
 /// Create and show a new editor window. Returns the new controller.
 - (MainWindowController *)openNewWindow;
 

--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -443,7 +443,26 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
 
 - (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication *)sender {
     // Windows NPP behaviour: no save prompts on quit.
-    // Each window saves session + backups, then closes silently.
+    _isTerminating = YES;
+    //
+    // Write the session ONCE, up front, covering every window — session.plist
+    // and the backup directory are shared, single resources. The teardown loop
+    // below removes each controller as it closes it, so a per-window save would
+    // see fewer and fewer windows: the last window to close would overwrite
+    // session.plist with only its own tabs and then delete every other window's
+    // backup file, discarding unsaved work that had never been written to disk.
+    //
+    // Skip it when no live window is left. That happens when the user quits by
+    // closing the last window: AppKit runs windowShouldClose: (which saved,
+    // while that window was still registered), then the close observer
+    // deregisters it, and only then does AppKit ask us to terminate. Saving
+    // again here would see the just-closed window gone and overwrite its
+    // session entry and backups — reintroducing the very loss above.
+    MainWindowController *saver = nil;
+    for (MainWindowController *mwc in _windowControllers)
+        if (!mwc.windowHasClosed) { saver = mwc; break; }
+    if (saver && [saver sessionPersistenceEnabled]) [saver saveSessionForAllWindows];
+
     for (NSInteger i = (NSInteger)_windowControllers.count - 1; i >= 0; i--) {
         MainWindowController *mwc = _windowControllers[i];
         NSWindow *win = mwc.window;

--- a/src/MainWindowController.h
+++ b/src/MainWindowController.h
@@ -3,6 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class EditorView;
+@class TabManager;
 
 @interface MainWindowController : NSWindowController
 
@@ -29,6 +30,32 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Restore the last session from ~/Library/Application Support/Nextpad++/session.plist.
 - (BOOL)restoreLastSession;
+
+/// The receiver's tab managers: primary view plus the horizontal/vertical split
+/// views, with nils omitted. Session saving walks every window's managers so a
+/// tab living in a secondary window is neither dropped from session.plist nor
+/// stripped of its backup file by the stale-backup prune.
+- (NSArray<TabManager *> *)sessionTabManagers;
+
+/// YES once the receiver's window has closed. A closed window's tabs are gone —
+/// the user closed them — so they no longer contribute to the session. Tracked
+/// explicitly rather than inferred from -[NSWindow isVisible], which is also NO
+/// for a merely miniaturized window.
+@property (nonatomic, readonly) BOOL windowHasClosed;
+
+/// Write session.plist covering the tabs of EVERY open window, and prune backup
+/// files no longer referenced by any of them.
+///
+/// This is app-scoped on purpose. session.plist and the backup directory are
+/// single, shared resources, so a per-window save would write only the closing
+/// window's tabs and then delete every other window's backups — losing the
+/// unsaved contents of all other windows. Call this once per quit, before any
+/// window is torn down.
+- (void)saveSessionForAllWindows;
+
+/// YES when the session should be persisted at all: the "Remember current
+/// session for next launch" pref is on and -nosession was not passed (#87).
+- (BOOL)sessionPersistenceEnabled;
 
 /// Add a plugin-provided toolbar icon.  Called by NppPluginManager when a
 /// plugin sends NPPM_ADDTOOLBARICON_FORDARKMODE.

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -1972,8 +1972,8 @@ static void _nppTahoeRoundEditorCard(NSView *container, NSView *content) {
     NSLayoutConstraint *_subTabBarVZeroHeight;
     NSTimer          *_autoSaveTimer;
     /// YES once restoreLastSession has successfully opened ≥1 tab from the
-    /// stored session this launch. Used by saveSession to decide whether the
-    /// "preserve when empty" guard applies — see saveSession's Issue #87
+    /// stored session this launch. Used by the session save to decide whether
+    /// the "preserve when empty" guard applies — see the Issue #87
     /// comment for details. (Bug fix: closing all restored tabs and quitting
     /// would otherwise leave the prior session.plist untouched, so the same
     /// tabs reappeared on next launch.)
@@ -4230,9 +4230,55 @@ static BOOL groupHasTrailingSep(NSString *ident) {
 
 #pragma mark - Session
 
+- (NSArray<TabManager *> *)sessionTabManagers {
+    NSMutableArray<TabManager *> *mgrs = [NSMutableArray array];
+    if (_tabManager)     [mgrs addObject:_tabManager];
+    if (_subTabManagerH) [mgrs addObject:_subTabManagerH];
+    if (_subTabManagerV) [mgrs addObject:_subTabManagerV];
+    return mgrs;
+}
+
+/// The controllers whose tabs belong in the session: every window that is still
+/// live, plus the receiver. The receiver is included unconditionally because the
+/// usual caller is a window in the middle of closing — its tabs are being closed
+/// as the app goes away, which is exactly the case that has always persisted.
+/// Windows the user closed earlier are excluded; those documents are gone.
+- (NSArray<MainWindowController *> *)_sessionContributingControllers {
+    NSMutableArray<MainWindowController *> *result = [NSMutableArray arrayWithObject:self];
+    id appDel = NSApp.delegate;
+    if (![appDel isKindOfClass:[AppDelegate class]]) return result;  // unit hosts
+
+    for (MainWindowController *mwc in [(AppDelegate *)appDel windowControllers])
+        if (mwc != self && !mwc.windowHasClosed) [result addObject:mwc];
+    return result;
+}
+
+- (void)saveSessionForAllWindows {
+    NSMutableArray<TabManager *> *mgrs = [NSMutableArray array];
+    for (MainWindowController *mwc in [self _sessionContributingControllers])
+        for (TabManager *mgr in [mwc sessionTabManagers])
+            if (![mgrs containsObject:mgr]) [mgrs addObject:mgr];
+
+    // Prefer the front window's active tab for selectedIndex — the save is often
+    // driven by the primary controller even when a secondary window has focus.
+    MainWindowController *key = nil;
+    for (MainWindowController *mwc in [self _sessionContributingControllers])
+        if (mwc.window.isKeyWindow) { key = mwc; break; }
+
+    [self saveSessionWithTabManagers:mgrs
+                       activeEditor:[(key ?: self) currentEditor]];
+}
+
 /// Save session to ~/Library/Application Support/Nextpad++/session.plist.
 /// Untitled modified tabs are written to ~/Library/Application Support/Nextpad++/backup/ automatically.
-- (void)saveSession {
+///
+/// `sessionManagers` must cover every tab whose backup should survive the
+/// stale-backup prune at the end — the prune deletes any backup file not claimed
+/// by one of these managers' editors. Callers therefore go through
+/// -saveSessionForAllWindows rather than passing one window's managers.
+/// `activeEditor` is the tab to reopen selected; ignored if it produced no entry.
+- (void)saveSessionWithTabManagers:(NSArray<TabManager *> *)sessionManagers
+                      activeEditor:(nullable EditorView *)activeEditor {
     ensureNppDirs();
     NSString *backupDir = nppBackupDir();
 
@@ -4250,7 +4296,8 @@ static BOOL groupHasTrailingSep(NSString *ident) {
     // session AND (because its backup wasn't added to activeBackups) deleted its
     // backup in the prune below — silent loss of unsaved content. Restored tabs
     // all reopen in the primary view (split layout is intentionally not kept).
-    NSArray<TabManager *> *sessionManagers = @[_tabManager, _subTabManagerH, _subTabManagerV];
+    // The same reasoning extends across windows, which is why the manager list
+    // is supplied by the caller (see -saveSessionForAllWindows).
     NSMutableArray<EditorView *> *sessionEditors = [NSMutableArray array];
     NSMapTable<EditorView *, TabManager *> *ownerManager =
         [NSMapTable strongToStrongObjectsMapTable];
@@ -4264,6 +4311,10 @@ static BOOL groupHasTrailingSep(NSString *ident) {
     }
 
     NSMutableArray *tabs = [NSMutableArray array];
+    // Parallel to `tabs`: which editor produced each entry. `tabs` skips
+    // untouched untitled tabs, so a tab-bar index is not an index into it —
+    // selectedIndex has to be resolved against this list.
+    NSMutableArray<EditorView *> *tabEditors = [NSMutableArray array];
     for (EditorView *ed in sessionEditors) {
         NSMutableDictionary *info = [NSMutableDictionary dictionary];
 
@@ -4341,6 +4392,7 @@ static BOOL groupHasTrailingSep(NSString *ident) {
         }
 
         [tabs addObject:info];
+        [tabEditors addObject:ed];
     }
 
     // Issue #87 (refined) — empty-session preserve guard.
@@ -4356,9 +4408,13 @@ static BOOL groupHasTrailingSep(NSString *ident) {
     //   NO  (didn't restore)  | preserve prior plist → original Issue #87 fix
     if (tabs.count == 0 && !_didRestoreSession) return;
 
+    // Resolve the active tab against `tabs`, not against a tab-bar index: with
+    // several windows (or a split view) the tab bars each start at 0, so a raw
+    // tab-bar index restores an unrelated document.
+    NSUInteger selIdx = activeEditor ? [tabEditors indexOfObject:activeEditor] : NSNotFound;
     NSDictionary *session = @{
         @"tabs":          tabs,
-        @"selectedIndex": @(_tabManager.tabBar.selectedIndex)
+        @"selectedIndex": @(selIdx == NSNotFound ? 0 : (NSInteger)selIdx)
     };
     [session writeToFile:nppSessionPath() atomically:YES];
 
@@ -4501,7 +4557,7 @@ static BOOL groupHasTrailingSep(NSString *ident) {
     if (sel < (NSInteger)_tabManager.allEditors.count)
         [_tabManager selectTabAtIndex:sel];
 
-    // Mark this launch as session-restored. saveSession uses this to allow
+    // Mark this launch as session-restored. The session save uses this to allow
     // writing an empty session.plist if the user explicitly closed all the
     // restored tabs before quitting (otherwise the empty-guard would keep
     // the stale session.plist around and the same tabs would reappear next
@@ -10726,6 +10782,10 @@ static int64_t _sysctlInt(const char *name) {
 #pragma mark - NSWindowDelegate
 
 - (void)windowWillClose:(NSNotification *)n {
+    // The session save already ran in -windowShouldClose:, while this window was
+    // still live. From here on the receiver must not contribute tabs to a later
+    // save — its documents are closed.
+    _windowHasClosed = YES;
     [_autoSaveTimer invalidate];
     _autoSaveTimer = nil;
     // The scroll-sync timer also targets self with repeats:YES; if a split with
@@ -10760,14 +10820,26 @@ static int64_t _sysctlInt(const char *name) {
     // Auto-backup of unsaved files runs separately on its own timer and is
     // intentionally NOT coupled — losing unsaved work to a crash is a separate
     // concern from reopening tabs across launches.
-    NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
-    BOOL rememberSession = [ud boolForKey:kPrefRememberSession];
+    //
+    // On quit, AppDelegate has already written one session covering every
+    // window (see -applicationShouldTerminate:). Saving again here would be
+    // actively harmful: by the time the second window is torn down the first is
+    // gone from windowControllers, so this save would write a session missing
+    // its tabs and prune away its backups.
     AppDelegate *appDel = (AppDelegate *)NSApp.delegate;
-    BOOL cliNoSession = [appDel isKindOfClass:[AppDelegate class]] ? appDel.cliParams.noSession : NO;
-    if (rememberSession && !cliNoSession) {
-        [self saveSession];
+    BOOL terminating = [appDel isKindOfClass:[AppDelegate class]] ? appDel.isTerminating : NO;
+    if (!terminating && [self sessionPersistenceEnabled]) {
+        [self saveSessionForAllWindows];
     }
     writeConfigXML();
+    return YES;
+}
+
+- (BOOL)sessionPersistenceEnabled {
+    NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
+    if (![ud boolForKey:kPrefRememberSession]) return NO;
+    AppDelegate *appDel = (AppDelegate *)NSApp.delegate;
+    if ([appDel isKindOfClass:[AppDelegate class]] && appDel.cliParams.noSession) return NO;
     return YES;
 }
 


### PR DESCRIPTION
session.plist and ~/Library/Application Support/Nextpad++/backup/ are single,
app-wide resources, but saveSession treated them as if they belonged to one
window. It enumerated only the receiver's three tab managers (primary +
horizontal/vertical split), wrote session.plist from that, and then deleted every
backup file in backup/ that none of those editors claimed.

For a modified file the on-disk copy survives that prune. An unsaved untitled
buffer exists *only* as its backup file, so deleting it destroys the text.

Two paths reach that outcome with more than one window open.

Quitting with Cmd-Q. applicationShouldTerminate: walks windowControllers
backwards, calling windowShouldClose: on each and removing it before moving on.
Each window in turn overwrote session.plist with only its own tabs and pruned the
other windows' backups. The main window is index 0 and therefore writes last, so
every secondary window's tabs vanished from the session and their backups were
deleted. Open a second window, type into a new tab, quit, relaunch: gone.

Quitting by closing the last window. AppKit runs windowShouldClose: (which
saved), the close observer deregisters that controller, and only then does
applicationShouldTerminateAfterLastWindowClosed: lead to
applicationShouldTerminate:. A save there no longer sees the window that just
closed, so it overwrites that window's session entry and prunes its backups.

The Issue #162 fix in this method covered exactly this hazard for split views; it
just stopped at the window boundary.

Fix: make session saving app-scoped and run it once per quit.

  - saveSessionForAllWindows collects tab managers from every contributing
    window, so the prune sees every live tab's backup as active.
  - "Contributing" is every window that has not closed, plus the receiver. A
    window the user closed earlier is gone and no longer contributes; the
    receiver always does, because the usual caller is a window closing as the app
    goes away — the case that has always persisted. windowHasClosed is tracked in
    windowWillClose: rather than read from -[NSWindow isVisible], which is also
    NO for a merely miniaturized window.
  - applicationShouldTerminate: performs that save once, before tearing anything
    down, and sets isTerminating so the per-window save in windowShouldClose:
    stands down for the rest of the quit. It skips the save entirely when no live
    window is left, which is the last-window-close path above: windowShouldClose:
    already saved while that window was still registered.
  - Closing one window while others stay open still saves, now app-scoped, so it
    can no longer delete another window's backups.

selectedIndex was also a tab-bar index while tabs[] is a filtered, cross-view
list (untouched untitled tabs are skipped, split-view tabs are appended). Every
tab bar starts at 0, so with a split or a second window it pointed at an
unrelated document. It is now resolved against the array actually written, and
against the front window's active tab rather than whichever controller happened
to drive the save.

Restoring still reopens everything in the primary window — window layout is not
persisted, matching how the split layout is intentionally not restored today.