### PR TITLE
Fix same-named buffers overwriting each other's auto-backup

### DIFF
--- a/src/EditorView.h
+++ b/src/EditorView.h
@@ -40,6 +40,15 @@ extern NSNotificationName const EditorViewDidSaveNotification;
 /// Write current content to dir using NPP-style timestamped filename.
 /// Updates backupFilePath on success. Returns the backup path or nil.
 - (nullable NSString *)saveBackupToDirectory:(NSString *)dir;
+
+/// `dir`/`filename`, made unique by appending "-2", "-3", … while a file already
+/// exists there. Backup names are "<display name>@<timestamp>" at one-second
+/// resolution, and neither part is unique across buffers: two tabs for
+/// same-named files in different directories, or an untitled "new 1" in each
+/// window, produce the same name when first backed up in the same second. Every
+/// caller that materialises a backup file must claim its name through here,
+/// because an unsaved buffer's backup is the only copy of its text.
++ (NSString *)uniqueBackupPathInDirectory:(NSString *)dir filename:(NSString *)filename;
 @property (nonatomic, readonly) BOOL isModified;
 @property (nonatomic, readonly) NSString *displayName;
 

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -857,6 +857,18 @@ static NSUInteger nppLargeFileThreshold(void) {
 /// no encoding roundtrip, preserves null bytes and BOM.
 /// Mirrors NPP Buffer.cpp: creates ONE timestamped file per buffer on first backup,
 /// then overwrites that same file in-place on every subsequent backup cycle.
++ (NSString *)uniqueBackupPathInDirectory:(NSString *)dir filename:(NSString *)filename {
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *path = [dir stringByAppendingPathComponent:filename];
+    // The suffix goes after the timestamp so the "@<timestamp>" tail that tab
+    // rename splits on (see -_renameUntitledTab: in MainWindowController) stays
+    // intact.
+    for (NSUInteger n = 2; [fm fileExistsAtPath:path]; n++)
+        path = [dir stringByAppendingPathComponent:
+                [NSString stringWithFormat:@"%@-%lu", filename, (unsigned long)n]];
+    return path;
+}
+
 - (nullable NSString *)saveBackupToDirectory:(NSString *)dir {
     NSString *dest = _backupFilePath;
 
@@ -869,7 +881,9 @@ static NSUInteger nppLargeFileThreshold(void) {
         fmt.dateFormat = @"yyyy-MM-dd_HHmmss";
         NSString *name = [NSString stringWithFormat:@"%@@%@", base,
                           [fmt stringFromDate:[NSDate date]]];
-        dest = [dir stringByAppendingPathComponent:name];
+        // Never reuse a name another buffer already claimed — the earlier
+        // buffer's unsaved text is the only copy and this write would erase it.
+        dest = [EditorView uniqueBackupPathInDirectory:dir filename:name];
     }
 
     // Get raw UTF-8 bytes directly from Scintilla (no NSString conversion)

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -8376,11 +8376,14 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
         NSString *suffix  = @"";
         NSRange at = [oldFile rangeOfString:@"@" options:NSBackwardsSearch];
         if (at.location != NSNotFound) suffix = [oldFile substringFromIndex:at.location];
-        NSString *newBackup = [dir stringByAppendingPathComponent:
-                               [newName stringByAppendingString:suffix]];
+        // Claim the new name through the uniquifier instead of deleting whatever
+        // sits there: renaming a tab to a name another buffer already backed up
+        // in the same second would otherwise destroy that buffer's only copy of
+        // its unsaved text.
+        NSString *newBackup = [EditorView uniqueBackupPathInDirectory:dir
+                                                            filename:[newName stringByAppendingString:suffix]];
         if (![newBackup isEqualToString:oldBackup]) {
             NSFileManager *fm = [NSFileManager defaultManager];
-            [fm removeItemAtPath:newBackup error:nil];               // overwrite any stale file
             if ([fm moveItemAtPath:oldBackup toPath:newBackup error:nil])
                 ed.backupFilePath = newBackup;
         }


### PR DESCRIPTION
Backup filenames are "<display name>@<yyyy-MM-dd_HHmmss>", built once per buffer
and then cached in backupFilePath. Neither half is unique across buffers, and the
write goes ahead unconditionally:

    NSString *name = [NSString stringWithFormat:@"%@@%@", base, stamp];
    dest = [dir stringByAppendingPathComponent:name];

`base` is the file's last path component, so two tabs on same-named files in
different directories share it, and the timestamp only resolves to one second.
saveSession backs the open editors up in a synchronous loop and the auto-backup
timer does the same, so two buffers taking their first backup in the same second
land on one path. The second atomic write replaces the first file, and both
editors then cache that same path — so both session entries point at it and on
restore both tabs show the second buffer's text.

Open /projects/alpha/README.md and /projects/beta/README.md in one window, modify
both, quit: one backup file exists where there should be two, and alpha's unsaved
changes are gone. The same applies to two same-named files in different split
views, and to an untitled "new 1" in each of two windows — untitledIndex is unique
only within a TabManager. Untitled buffers are the worst case, because their
backup file is the only copy of their text anywhere.

Fix: route every backup-name claim through
+[EditorView uniqueBackupPathInDirectory:filename:], which appends "-2", "-3", …
while a file already exists at the path. The name is claimed before the write and
saveBackupToDirectory: caches it, so a buffer still keeps one stable backup file
for its lifetime. The probe is sufficient for these callers because they all run
serially on the main thread and saveBackupToDirectory: completes its synchronous
write before returning, so the next editor sees the file already on disk.

Tab rename had the same hazard from the other direction and is fixed with it. It
moves the backup to "<new name>@<timestamp>" and previously did

    [fm removeItemAtPath:newBackup error:nil];   // overwrite any stale file

which destroys a live buffer's backup when the new name collides with one. It now
claims the destination through the same uniquifier. The disambiguator is appended
after the timestamp so the "@<timestamp>" tail that rename splits on (the last "@"
in the name) survives, including when an already-disambiguated file is renamed
again.

One cosmetic consequence: a stale colliding file left over from an earlier run now
pushes a live backup to "-2" rather than being overwritten. That stale file is
removed by the usual stale-backup prune at the end of the next session save.