### PR TITLE
Fixes #270 Assignable keys +, -

### DIFF
--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -15,6 +15,36 @@
 // Files opened from a folder beyond this count trigger a confirmation.
 static const NSUInteger kFolderOpenConfirmThreshold = 20;
 
+static NSString *NPPMenuKeyEquivalentForShortcutKeyCode(NSUInteger keyCode) {
+    if (keyCode >= 'A' && keyCode <= 'Z')
+        return [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
+    if (keyCode >= '0' && keyCode <= '9')
+        return [NSString stringWithFormat:@"%c", (char)keyCode];
+    if (keyCode >= 112 && keyCode <= 123) {
+        unichar fk = NSF1FunctionKey + (keyCode - 112);
+        return [NSString stringWithCharacters:&fk length:1];
+    }
+    switch (keyCode) {
+        case 8:   return [NSString stringWithFormat:@"%C", (unichar)NSBackspaceCharacter];
+        case 9:   return @"\t";
+        case 13:  return @"\r";
+        case 27:  return [NSString stringWithFormat:@"%C", (unichar)0x1B];
+        case 46:  return [NSString stringWithFormat:@"%C", (unichar)NSDeleteCharacter];
+        case 186: return @";";
+        case 187: return @"=";
+        case 188: return @",";
+        case 189: return @"-";
+        case 190: return @".";
+        case 191: return @"/";
+        case 192: return @"`";
+        case 219: return @"[";
+        case 220: return @"\\";
+        case 221: return @"]";
+        case 222: return @"'";
+        default:  return [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
+    }
+}
+
 @interface AppDelegate ()
 - (NSArray<NSString *> *)_expandFolderArguments:(NSArray<NSString *> *)paths;
 @end
@@ -608,18 +638,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
             if (hasAlt)   mods |= NSEventModifierFlagOption;
             if (hasShift) mods |= NSEventModifierFlagShift;
 
-            NSString *key = @"";
-            if (keyCode >= 'A' && keyCode <= 'Z')
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-            else if (keyCode >= '0' && keyCode <= '9')
-                key = [NSString stringWithFormat:@"%c", (char)keyCode];
-            else if (keyCode >= 112 && keyCode <= 123) {
-                unichar fk = NSF1FunctionKey + (keyCode - 112);
-                key = [NSString stringWithCharacters:&fk length:1];
-            } else
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-
-            mi.keyEquivalent = key;
+            mi.keyEquivalent = NPPMenuKeyEquivalentForShortcutKeyCode(keyCode);
             mi.keyEquivalentModifierMask = mods;
         }
     };

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -109,6 +109,71 @@ static void addMacroToShortcutsXML(NSString *name, NSArray<NSDictionary *> *acti
                                    BOOL ctrl, BOOL alt, BOOL shift, BOOL cmd, NSUInteger keyCode);
 static void removeMacroFromShortcutsXML(NSString *name);
 
+static NSUInteger NPPShortcutKeyCodeForPopupName(NSString *name) {
+    if ([name isEqualToString:@"None"] || name.length == 0) return 0;
+    NSDictionary *map = @{@"Backspace":@8, @"Tab":@9, @"Enter":@13, @"Escape":@27, @"Space":@32,
+        @"Page Up":@33, @"Page Down":@34, @"End":@35, @"Home":@36, @"Left":@37, @"Up":@38,
+        @"Right":@39, @"Down":@40, @"Insert":@45, @"Delete":@46, @";":@186, @"+":@187, @"=":@187,
+        @",":@188, @"-":@189, @".":@190, @"/":@191, @"`":@192, @"[":@219, @"\\":@220,
+        @"]":@221, @"'":@222};
+    NSNumber *mapped = map[name];
+    if (mapped) return mapped.unsignedIntegerValue;
+    if (name.length == 1) return [name characterAtIndex:0];
+    if ([name hasPrefix:@"F"] && name.length <= 3) return 111 + [name substringFromIndex:1].intValue;
+    return 0;
+}
+
+static NSUInteger NPPShortcutKeyCodeForMenuKeyEquivalent(NSString *keyEquivalent) {
+    if (!keyEquivalent.length) return 0;
+    unichar key = [keyEquivalent.uppercaseString characterAtIndex:0];
+    if (key >= 0xF704 && key <= 0xF70F) return 112 + (key - 0xF704);
+    switch (key) {
+        case ';': return 186;
+        case '=': return 187;
+        case '+': return 187;
+        case ',': return 188;
+        case '-': return 189;
+        case '.': return 190;
+        case '/': return 191;
+        case '`': return 192;
+        case '[': return 219;
+        case '\\': return 220;
+        case ']': return 221;
+        case '\'': return 222;
+        default: return key;
+    }
+}
+
+static NSString *NPPMenuKeyEquivalentForShortcutKeyCode(NSUInteger keyCode) {
+    if (keyCode >= 'A' && keyCode <= 'Z')
+        return [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
+    if (keyCode >= '0' && keyCode <= '9')
+        return [NSString stringWithFormat:@"%c", (char)keyCode];
+    if (keyCode >= 112 && keyCode <= 123) {
+        unichar fk = NSF1FunctionKey + (keyCode - 112);
+        return [NSString stringWithCharacters:&fk length:1];
+    }
+    switch (keyCode) {
+        case 8:   return [NSString stringWithFormat:@"%C", (unichar)NSBackspaceCharacter];
+        case 9:   return @"\t";
+        case 13:  return @"\r";
+        case 27:  return [NSString stringWithFormat:@"%C", (unichar)0x1B];
+        case 46:  return [NSString stringWithFormat:@"%C", (unichar)NSDeleteCharacter];
+        case 186: return @";";
+        case 187: return @"=";
+        case 188: return @",";
+        case 189: return @"-";
+        case 190: return @".";
+        case 191: return @"/";
+        case 192: return @"`";
+        case 219: return @"[";
+        case 220: return @"\\";
+        case 221: return @"]";
+        case 222: return @"'";
+        default:  return [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
+    }
+}
+
 #pragma mark - Context menu XML parser
 
 /// Walk a menu recursively to find an item by title (case-insensitive, strips shortcuts).
@@ -5341,7 +5406,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
         for (int i = 1; i <= 12; i++) [keys addObject:[NSString stringWithFormat:@"F%d", i]];
         [keys addObjectsFromArray:@[@"Backspace", @"Tab", @"Enter", @"Escape", @"Space",
             @"Page Up", @"Page Down", @"End", @"Home", @"Left", @"Up", @"Right", @"Down",
-            @"Insert", @"Delete", @";", @"=", @",", @"-", @".", @"/", @"`", @"[", @"\\", @"]", @"'"]];
+            @"Insert", @"Delete", @";", @"+", @"=", @",", @"-", @".", @"/", @"`", @"[", @"\\", @"]", @"'"]];
         [keyPopup addItemsWithTitles:keys];
     }
     [cv addSubview:keyPopup];
@@ -5390,9 +5455,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
             btnOK.enabled = YES;          // no key → no possible conflict
             return;
         }
-        NSUInteger keyCode = 0;
-        if (keyName.length == 1) keyCode = [keyName characterAtIndex:0];
-        else if ([keyName hasPrefix:@"F"]) keyCode = 111 + [keyName substringFromIndex:1].intValue;
+        NSUInteger keyCode = NPPShortcutKeyCodeForPopupName(keyName);
         if (keyCode == 0) {
             conflictLabel.stringValue = @"";
             btnOK.enabled = YES;
@@ -5411,8 +5474,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
                 BOOL mCtrl = (m & NSEventModifierFlagControl) != 0;
                 BOOL mAlt = (m & NSEventModifierFlagOption) != 0;
                 BOOL mShift = (m & NSEventModifierFlagShift) != 0;
-                unichar mKey = [mi.keyEquivalent.uppercaseString characterAtIndex:0];
-                if (mKey >= 0xF704 && mKey <= 0xF70F) mKey = 112 + (mKey - 0xF704);
+                NSUInteger mKey = NPPShortcutKeyCodeForMenuKeyEquivalent(mi.keyEquivalent);
                 if (mKey == keyCode &&
                     mCmd == (chkCmd.state == NSControlStateValueOn) &&
                     mCtrl == (chkCtrl.state == NSControlStateValueOn) &&
@@ -5481,13 +5543,8 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     BOOL macroCtrl  = (chkCtrl.state == NSControlStateValueOn);
     BOOL macroAlt   = (chkOpt.state == NSControlStateValueOn);
     BOOL macroShift = (chkShift.state == NSControlStateValueOn);
-    NSUInteger macroKeyCode = 0;
     NSString *keyName = keyPopup.titleOfSelectedItem;
-    if (keyName.length == 1) {
-        macroKeyCode = [keyName characterAtIndex:0]; // 'A'-'Z' or '0'-'9'
-    } else if ([keyName hasPrefix:@"F"]) {
-        macroKeyCode = 111 + [keyName substringFromIndex:1].intValue; // F1=112..F12=123
-    }
+    NSUInteger macroKeyCode = NPPShortcutKeyCodeForPopupName(keyName);
 
     ensureNppDirs();
     // Insert macro into shortcuts.xml in-place (preserves rest of file)
@@ -5565,18 +5622,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
             if (hasAlt)   mods |= NSEventModifierFlagOption;
             if (hasShift) mods |= NSEventModifierFlagShift;
 
-            NSString *key = @"";
-            if (keyCode >= 'A' && keyCode <= 'Z')
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-            else if (keyCode >= '0' && keyCode <= '9')
-                key = [NSString stringWithFormat:@"%c", (char)keyCode];
-            else if (keyCode >= 112 && keyCode <= 123) {
-                unichar fk = NSF1FunctionKey + (keyCode - 112);
-                key = [NSString stringWithCharacters:&fk length:1];
-            } else
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-
-            item.keyEquivalent = key;
+            item.keyEquivalent = NPPMenuKeyEquivalentForShortcutKeyCode(keyCode);
             item.keyEquivalentModifierMask = mods;
         }
 
@@ -5641,13 +5687,9 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
             if (hasAlt)   mods |= NSEventModifierFlagOption;
             if (hasShift) mods |= NSEventModifierFlagShift;
 
-            unichar kc = 0;
-            if (keyCode >= 112 && keyCode <= 123) kc = NSF1FunctionKey + (keyCode - 112);
-            else if (keyCode >= 'A' && keyCode <= 'Z') kc = keyCode + 32;
-            else if (keyCode >= '0' && keyCode <= '9') kc = keyCode;
-            else kc = keyCode;
-            if (kc) {
-                item.keyEquivalent = [NSString stringWithCharacters:&kc length:1];
+            NSString *key = NPPMenuKeyEquivalentForShortcutKeyCode(keyCode);
+            if (key.length) {
+                item.keyEquivalent = key;
                 item.keyEquivalentModifierMask = mods;
             }
         }
@@ -9298,6 +9340,9 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
         [keyPopup addItemWithTitle:[NSString stringWithFormat:@"%c", c]];
     for (int i = 1; i <= 12; i++)
         [keyPopup addItemWithTitle:[NSString stringWithFormat:@"F%d", i]];
+    [keyPopup addItemsWithTitles:@[@"Backspace", @"Tab", @"Enter", @"Escape", @"Space",
+        @"Page Up", @"Page Down", @"End", @"Home", @"Left", @"Up", @"Right", @"Down",
+        @"Insert", @"Delete", @";", @"+", @"=", @",", @"-", @".", @"/", @"`", @"[", @"\\", @"]", @"'"]];
     [cv addSubview:keyPopup];
 
     // Conflict warning label
@@ -9340,9 +9385,7 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
             btnOK.enabled = YES;
             return;
         }
-        NSUInteger keyCode = 0;
-        if (keyName.length == 1) keyCode = [keyName characterAtIndex:0];
-        else if ([keyName hasPrefix:@"F"]) keyCode = 111 + [keyName substringFromIndex:1].intValue;
+        NSUInteger keyCode = NPPShortcutKeyCodeForPopupName(keyName);
         if (keyCode == 0) {
             conflictLabel.stringValue = @"";
             btnOK.enabled = YES;
@@ -9360,8 +9403,7 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
                 BOOL mCtrl = (m & NSEventModifierFlagControl) != 0;
                 BOOL mAlt = (m & NSEventModifierFlagOption) != 0;
                 BOOL mShift = (m & NSEventModifierFlagShift) != 0;
-                unichar mKey = [mi.keyEquivalent.uppercaseString characterAtIndex:0];
-                if (mKey >= 0xF704 && mKey <= 0xF70F) mKey = 112 + (mKey - 0xF704);
+                NSUInteger mKey = NPPShortcutKeyCodeForMenuKeyEquivalent(mi.keyEquivalent);
                 if (mKey == keyCode &&
                     mCmd == (chkCmd.state == NSControlStateValueOn) &&
                     mCtrl == (chkCtrl.state == NSControlStateValueOn) &&
@@ -9423,25 +9465,7 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
     BOOL hasOpt   = (chkOpt.state == NSControlStateValueOn);
     BOOL hasShift = (chkShift.state == NSControlStateValueOn);
     NSString *keyTitle = keyPopup.titleOfSelectedItem;
-    int keyCode = 0;
-    if ([keyTitle isEqualToString:@"None"]) keyCode = 0;
-    else if (keyTitle.length == 1) keyCode = [keyTitle characterAtIndex:0];
-    else if ([keyTitle hasPrefix:@"F"] && keyTitle.length <= 3) keyCode = 111 + [keyTitle substringFromIndex:1].intValue;
-    else if ([keyTitle isEqualToString:@"Backspace"]) keyCode = 8;
-    else if ([keyTitle isEqualToString:@"Tab"]) keyCode = 9;
-    else if ([keyTitle isEqualToString:@"Enter"]) keyCode = 13;
-    else if ([keyTitle isEqualToString:@"Escape"]) keyCode = 27;
-    else if ([keyTitle isEqualToString:@"Space"]) keyCode = 32;
-    else if ([keyTitle isEqualToString:@"Page Up"]) keyCode = 33;
-    else if ([keyTitle isEqualToString:@"Page Down"]) keyCode = 34;
-    else if ([keyTitle isEqualToString:@"End"]) keyCode = 35;
-    else if ([keyTitle isEqualToString:@"Home"]) keyCode = 36;
-    else if ([keyTitle isEqualToString:@"Left"]) keyCode = 37;
-    else if ([keyTitle isEqualToString:@"Up"]) keyCode = 38;
-    else if ([keyTitle isEqualToString:@"Right"]) keyCode = 39;
-    else if ([keyTitle isEqualToString:@"Down"]) keyCode = 40;
-    else if ([keyTitle isEqualToString:@"Insert"]) keyCode = 45;
-    else if ([keyTitle isEqualToString:@"Delete"]) keyCode = 46;
+    int keyCode = (int)NPPShortcutKeyCodeForPopupName(keyTitle);
 
     // Insert into shortcuts.xml using raw text manipulation (preserves file structure)
     NSString *shortcutsPath = NppConfigSubpath(@"shortcuts.xml");

--- a/src/ShortcutMapperWindowController.mm
+++ b/src/ShortcutMapperWindowController.mm
@@ -64,7 +64,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
         case 45:  return @"Ins";
         case 46:  return @"\u2326"; // ⌦ Delete
         case 186: return @";";
-        case 187: return @"=";
+        case 187: return @"+";
         case 188: return @",";
         case 189: return @"-";
         case 190: return @".";
@@ -95,7 +95,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     for (int i = 1; i <= 12; i++) [keys addObject:[NSString stringWithFormat:@"F%d", i]];
     [keys addObjectsFromArray:@[@"Backspace", @"Tab", @"Enter", @"Escape", @"Space",
         @"Page Up", @"Page Down", @"End", @"Home", @"Left", @"Up", @"Right", @"Down",
-        @"Insert", @"Delete", @";", @"=", @",", @"-", @".", @"/", @"`", @"[", @"\\", @"]", @"'"]];
+        @"Insert", @"Delete", @";", @"+", @"=", @",", @"-", @".", @"/", @"`", @"[", @"\\", @"]", @"'"]];
     return keys;
 }
 
@@ -108,7 +108,7 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     NSDictionary *map = @{@8:@"Backspace", @9:@"Tab", @13:@"Enter", @27:@"Escape", @32:@"Space",
         @33:@"Page Up", @34:@"Page Down", @35:@"End", @36:@"Home", @37:@"Left", @38:@"Up",
         @39:@"Right", @40:@"Down", @45:@"Insert", @46:@"Delete",
-        @186:@";", @187:@"=", @188:@",", @189:@"-", @190:@".", @191:@"/",
+        @186:@";", @187:@"+", @188:@",", @189:@"-", @190:@".", @191:@"/",
         @192:@"`", @219:@"[", @220:@"\\", @221:@"]", @222:@"'",
         @0xF728:@"Delete", @0xF729:@"Home", @0xF72B:@"End",
         @0xF72C:@"Page Up", @0xF72D:@"Page Down",
@@ -118,14 +118,46 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
 
 + (NSUInteger)keyCodeForName:(NSString *)name {
     if ([name isEqualToString:@"None"] || name.length == 0) return 0;
-    if (name.length == 1) return [name characterAtIndex:0];
-    if ([name hasPrefix:@"F"] && name.length <= 3) return 111 + [name substringFromIndex:1].intValue;
     NSDictionary *map = @{@"Backspace":@8, @"Tab":@9, @"Enter":@13, @"Escape":@27, @"Space":@32,
         @"Page Up":@33, @"Page Down":@34, @"End":@35, @"Home":@36, @"Left":@37, @"Up":@38,
-        @"Right":@39, @"Down":@40, @"Insert":@45, @"Delete":@46, @";":@186, @"=":@187,
+        @"Right":@39, @"Down":@40, @"Insert":@45, @"Delete":@46, @";":@186, @"+":@187, @"=":@187,
         @",":@188, @"-":@189, @".":@190, @"/":@191, @"`":@192, @"[":@219, @"\\":@220,
         @"]":@221, @"'":@222};
-    return [map[name] unsignedIntegerValue];
+    NSNumber *mapped = map[name];
+    if (mapped) return mapped.unsignedIntegerValue;
+    if (name.length == 1) return [name characterAtIndex:0];
+    if ([name hasPrefix:@"F"] && name.length <= 3) return 111 + [name substringFromIndex:1].intValue;
+    return 0;
+}
+
++ (NSString *)menuKeyEquivalentForCode:(NSUInteger)code {
+    if (code >= 'A' && code <= 'Z')
+        return [[NSString stringWithFormat:@"%c", (char)code] lowercaseString];
+    if (code >= '0' && code <= '9')
+        return [NSString stringWithFormat:@"%c", (char)code];
+    if (code >= 112 && code <= 123) {
+        unichar fk = NSF1FunctionKey + (code - 112);
+        return [NSString stringWithCharacters:&fk length:1];
+    }
+    switch (code) {
+        case 8:   return [NSString stringWithFormat:@"%C", (unichar)NSBackspaceCharacter];
+        case 9:   return @"\t";
+        case 13:  return @"\r";
+        case 27:  return [NSString stringWithFormat:@"%C", (unichar)0x1B];
+        case 46:  return [NSString stringWithFormat:@"%C", (unichar)NSDeleteCharacter];
+        case 186: return @";";
+        case 187: return @"=";
+        case 188: return @",";
+        case 189: return @"-";
+        case 190: return @".";
+        case 191: return @"/";
+        case 192: return @"`";
+        case 219: return @"[";
+        case 220: return @"\\";
+        case 221: return @"]";
+        case 222: return @"'";
+        default:  return [[NSString stringWithFormat:@"%c", (char)code] lowercaseString];
+    }
 }
 @end
 
@@ -1234,25 +1266,9 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     if (e.hasAlt)   mods |= NSEventModifierFlagOption;
     if (e.hasShift) mods |= NSEventModifierFlagShift;
 
-    NSString *key = @"";
-    if (e.keyCode >= 'A' && e.keyCode <= 'Z') {
-        key = [[NSString stringWithFormat:@"%c", (char)e.keyCode] lowercaseString];
-    } else if (e.keyCode >= '0' && e.keyCode <= '9') {
-        key = [NSString stringWithFormat:@"%c", (char)e.keyCode];
-    } else if (e.keyCode >= 112 && e.keyCode <= 123) {
-        unichar fk = NSF1FunctionKey + (e.keyCode - 112);
-        key = [NSString stringWithCharacters:&fk length:1];
+    NSString *key = [ShortcutEntry menuKeyEquivalentForCode:e.keyCode];
+    if (e.keyCode >= 112 && e.keyCode <= 123) {
         mods &= ~NSEventModifierFlagCommand; // function keys don't need Cmd implicit
-    } else {
-        // Special keys
-        switch (e.keyCode) {
-            case 8:  key = [NSString stringWithFormat:@"%C", (unichar)NSBackspaceCharacter]; break;
-            case 9:  key = @"\t"; break;
-            case 13: key = @"\r"; break;
-            case 27: key = [NSString stringWithFormat:@"%C", (unichar)0x1B]; break;
-            case 46: key = [NSString stringWithFormat:@"%C", (unichar)NSDeleteCharacter]; break;
-            default: key = [[NSString stringWithFormat:@"%c", (char)e.keyCode] lowercaseString]; break;
-        }
     }
     mi.keyEquivalent = key;
     mi.keyEquivalentModifierMask = mods;


### PR DESCRIPTION
## fixes #270

### the problem

The shortcut key picker could not assign plus, and selecting minus stored the wrong key code. `-` was treated as the generic single-character ASCII value 45, which is also the saved Insert virtual-key code, so it round-tripped as Insert instead of minus.

### root cause

The popup-name to key-code conversion returned one-character names before checking the punctuation virtual-key mappings. The menu shortcut application paths also converted saved OEM virtual-key codes back to raw character values instead of explicit macOS key equivalents.

### the fix

Map punctuation names before the generic one-character fallback, add `+` to the shortcut popups, and convert saved OEM punctuation key codes back to real macOS menu key equivalents when shortcuts are applied. The macro and run-command shortcut paths use the same conversion helpers so saved shortcuts round-trip consistently.

### files changed

- `src/ShortcutMapperWindowController.mm` — shortcut mapper key list, display, save, and live menu application
- `src/AppDelegate.mm` — startup shortcut override application
- `src/MainWindowController.mm` — macro and run-command shortcut dialogs/rebuild paths

### testing

- `git diff --check upstream/main...HEAD` passes
- `cmake --build build --target src/ShortcutMapperWindowController.o src/AppDelegate.o src/MainWindowController.o` passes (existing nullability/deprecation warnings only)
- prior full app build compiled and linked the executable, then failed in the post-build LaunchServices registration step with `failed to scan ... Nextpad++.app: -10822`