### PR TITLE
Fix build break in Replace in Files / Replace in Projects

### DIFF
--- a/src/FindWindow.mm
+++ b/src/FindWindow.mm
@@ -1032,32 +1032,23 @@ static CGFloat _fromTop(NSView *container, CGFloat topOffset, CGFloat height) {
                 NSString *content = [NSString stringWithContentsOfFile:fr.filePath
                                                              encoding:NSUTF8StringEncoding error:nil];
                 if (!content) continue;
-                NSString *search = opts.searchText;
-                NSString *repl = opts.replaceText ?: @"";
-                if (opts.searchType == NPPSearchExtended) {
-                    search = [SearchEngine expandExtendedString:search];
-                    repl = [SearchEngine expandExtendedString:repl];
-                }
-                NSStringCompareOptions cmp = opts.matchCase ? 0 : NSCaseInsensitiveSearch;
-                NSString *replaced = [content stringByReplacingOccurrencesOfString:search withString:repl
-                                                                          options:cmp range:NSMakeRange(0, content.length)];
-                if (![replaced isEqualToString:content]) {
+                NSInteger replacementCount = 0;
+                NSString *replaced = [SearchEngine stringByReplacingAllInString:content
+                                                                         options:opts
+                                                                replacementCount:&replacementCount];
+                // A replacement can be a no-op ("foo" -> "foo", regex (foo) -> \1).
+                // Comparing the text as well as the count keeps those files from
+                // being rewritten, which would bump their mtime for no reason.
+                if (replacementCount > 0 && ![replaced isEqualToString:content]) {
                     NSError *writeError = nil;
                     if ([replaced writeToFile:fr.filePath atomically:YES
                                      encoding:NSUTF8StringEncoding error:&writeError]) {
-                        totalReplacements += (NSInteger)fr.results.count;
+                        totalReplacements += replacementCount;
                         changedFiles++;
                     } else {
                         [writeFailures addObject:[NSString stringWithFormat:@"%@: %@",
                             fr.filePath, writeError.localizedDescription ?: @"Unknown write error"]];
                     }
-                NSInteger replacementCount = 0;
-                NSString *replaced = [SearchEngine stringByReplacingAllInString:content
-                                                                         options:opts
-                                                                replacementCount:&replacementCount];
-                if (replacementCount > 0) {
-                    [replaced writeToFile:fr.filePath atomically:YES encoding:NSUTF8StringEncoding error:nil];
-                    totalReplacements += replacementCount;
                 }
             }
             [self _showStatus:[NSString stringWithFormat:[[NppLocalizer shared] translate:@"Replace in Files: %ld replacement(s) in %ld file(s)."],
@@ -1204,32 +1195,23 @@ static CGFloat _fromTop(NSView *container, CGFloat topOffset, CGFloat height) {
                 NSString *content = [NSString stringWithContentsOfFile:fr.filePath
                                                              encoding:NSUTF8StringEncoding error:nil];
                 if (!content) continue;
-                NSString *search = opts.searchText;
-                NSString *repl = opts.replaceText ?: @"";
-                if (opts.searchType == NPPSearchExtended) {
-                    search = [SearchEngine expandExtendedString:search];
-                    repl = [SearchEngine expandExtendedString:repl];
-                }
-                NSStringCompareOptions cmp = opts.matchCase ? 0 : NSCaseInsensitiveSearch;
-                NSString *replaced = [content stringByReplacingOccurrencesOfString:search withString:repl
-                                                                          options:cmp range:NSMakeRange(0, content.length)];
-                if (![replaced isEqualToString:content]) {
+                NSInteger replacementCount = 0;
+                NSString *replaced = [SearchEngine stringByReplacingAllInString:content
+                                                                         options:opts
+                                                                replacementCount:&replacementCount];
+                // A replacement can be a no-op ("foo" -> "foo", regex (foo) -> \1).
+                // Comparing the text as well as the count keeps those files from
+                // being rewritten, which would bump their mtime for no reason.
+                if (replacementCount > 0 && ![replaced isEqualToString:content]) {
                     NSError *writeError = nil;
                     if ([replaced writeToFile:fr.filePath atomically:YES
                                      encoding:NSUTF8StringEncoding error:&writeError]) {
-                        totalReplacements += (NSInteger)fr.results.count;
+                        totalReplacements += replacementCount;
                         changedFiles++;
                     } else {
                         [writeFailures addObject:[NSString stringWithFormat:@"%@: %@",
                             fr.filePath, writeError.localizedDescription ?: @"Unknown write error"]];
                     }
-                NSInteger replacementCount = 0;
-                NSString *replaced = [SearchEngine stringByReplacingAllInString:content
-                                                                         options:opts
-                                                                replacementCount:&replacementCount];
-                if (replacementCount > 0) {
-                    [replaced writeToFile:fr.filePath atomically:YES encoding:NSUTF8StringEncoding error:nil];
-                    totalReplacements += replacementCount;
                 }
             }
             [self _showStatus:[NSString stringWithFormat:


### PR DESCRIPTION
`main` has not compiled since 8650374 (2026-07-29).

That commit resolved the conflict between #260 (*Fix cross-file replacement semantics*) and #261 (*Report cross-file replacement write failures*) by keeping **both** sides of the conflict, in both `-_replaceInFiles:` and `-_replaceInProjects:`. Each method ends up declaring `NSString *replaced` twice and leaving an `if` block unclosed:

```
src/FindWindow.mm:1066:10: error: expected expression
src/FindWindow.mm:1418:5: error: expected ')'
src/FindWindow.mm:1418:5: error: expected '}'
```

`FindWindow.mm.o` fails, so the app does not link. A clean checkout of `main` cannot be built.

### The fix

Keep what both changes were for, and drop the superseded code:

- **Replacement goes through `SearchEngine stringByReplacingAllInString:options:replacementCount:`** (#260). The manual `stringByReplacingOccurrencesOfString:` path left behind is not just redundant — it was *wrong*: it applied regex patterns literally and ignored Whole Word, while the helper expands extended sequences, honours Match Case, applies whole-word matching and evaluates regex line by line, the same way the search preview does.
- **Write failures are reported** through `writeFailures` / `_showReplaceWriteFailures:` (#261) instead of the `NSError` being discarded with `error:nil`.
- **`totalReplacements` counts `replacementCount`, not `fr.results.count`** (#260). The finder records only the first match per line, so the old accumulator reported matching *lines*, not replacements.

One addition beyond restoring the two originals: the write is now guarded on the text having actually changed, not only on the count being positive.

```objc
if (replacementCount > 0 && ![replaced isEqualToString:content]) {
```

A replacement can legitimately be a no-op — `"foo"` → `"foo"`, or regex `(foo)` → `\1`. Without the text comparison those files get rewritten, which bumps their mtime for no reason and can surface a spurious write error (and, with File Status Auto-Detection on, an external-change prompt). #260's original `![replaced isEqualToString:content]` guard had this property; the count-only guard lost it.

### Verification

- `ninja` from a clean tree: 0 errors, links and code-signs.
- Both methods re-read in full for scope balance, shadowed declarations and uninitialised use.
- Independently reviewed by a second model, which confirmed the semantics of both original changes are preserved and that the deleted path had no behaviour the helper lacks; the no-op guard above came out of that review.
