### PR TITLE
Stop monitoring mode from discarding unsaved edits

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -286,6 +286,8 @@ static NSUInteger nppLargeFileThreshold(void) {
     NSDate            *_lastKnownModDate; // mtime recorded after each load/save
     BOOL               _externalChangePending;
     BOOL               _monitoringMode;   // tail -f: auto-reload silently
+    NSInteger          _reloadFailureCount; // consecutive failed silent reloads
+    BOOL               _externalChangeMuted; // user kept their version; stop asking
 
     // Spell check
     BOOL               _spellCheckEnabled;
@@ -1011,24 +1013,60 @@ static NSUInteger nppLargeFileThreshold(void) {
     BOOL updateSilently = [ud boolForKey:kPrefFileStatusUpdateSilently];
     if (!autoDetect && !_monitoringMode) return;
 
-    _lastKnownModDate = mtime;
+    // The user already chose to keep their version of this file. Do not ask
+    // again while those edits are still unsaved: on a file that keeps changing —
+    // a log being appended to, which is exactly what a monitored tab watches —
+    // every later revision has a newer mtime and would raise the same prompt
+    // again a second later, with no answer that makes it stop. Saving or
+    // reloading clears the buffer's dirty flag and re-arms detection.
+    if (_externalChangeMuted) {
+        if (_isModified) { _lastKnownModDate = mtime; return; }
+        _externalChangeMuted = NO;
+    }
+
     _externalChangePending = YES;
 
     // Reload without prompting when this tab is monitoring (tail -f), or when
-    // "Update silently" is on and the buffer has no unsaved edits. Dirty buffers
-    // always fall through to the prompt so unsaved changes are never discarded
-    // silently. Both silent paths preserve the caret (line + column) and scroll
-    // position; loadFileAtPath: otherwise resets the caret to 0, which would
-    // snap the view back to the top on every external change.
-    if (_monitoringMode || (updateSilently && !_isModified)) {
+    // "Update silently" is on — in both cases only while the buffer has no
+    // unsaved edits. Dirty buffers always fall through to the prompt so unsaved
+    // changes are never discarded silently. Both silent paths preserve the caret
+    // (line + column) and scroll position; loadFileAtPath: otherwise resets the
+    // caret to 0, which would snap the view back to the top on every external
+    // change.
+    //
+    // _lastKnownModDate is deliberately not advanced here. loadFileAtPath:
+    // records it itself on success, and the paths below record it when the user
+    // declines the reload. Advancing it up front made a load that never happened
+    // look like one that had, so a transient read error lost the change for good.
+    if ((_monitoringMode || updateSilently) && !_isModified) {
         ScintillaView *sci = _scintillaView;
         sptr_t savedPos          = [sci message:SCI_GETCURRENTPOS];
         sptr_t savedLine         = [sci message:SCI_LINEFROMPOSITION wParam:(uptr_t)savedPos];
         sptr_t savedColumn       = [sci message:SCI_GETCOLUMN wParam:(uptr_t)savedPos];
         sptr_t savedFirstVisible = [sci message:SCI_GETFIRSTVISIBLELINE];
 
-        NSError *err;
-        [self loadFileAtPath:_filePath error:&err];
+        NSError *err = nil;
+        if (![self loadFileAtPath:_filePath error:&err]) {
+            // A cancelled large-file prompt is a decision, not a failure: record
+            // the mtime so the same version is not offered again every second.
+            //
+            // Any other error leaves _lastKnownModDate alone so the next poll
+            // retries, which is the point — a transient read error must not be
+            // recorded as a reload that happened. Give up after a few attempts
+            // though, or a persistent failure (permissions, a vanished network
+            // volume) becomes a failing read every second for as long as the tab
+            // is open.
+            static const NSInteger kMaxReloadRetries = 3;
+            if (([err.domain isEqualToString:NSCocoaErrorDomain] &&
+                 err.code == NSUserCancelledError) ||
+                ++_reloadFailureCount >= kMaxReloadRetries) {
+                _lastKnownModDate = mtime;
+                _reloadFailureCount = 0;
+            }
+            _externalChangePending = NO;
+            return;
+        }
+        _reloadFailureCount = 0;
 
         // Clamp to the reloaded file's bounds — guards the case where the
         // file shrank and the old caret line no longer exists. SCI_FINDCOLUMN
@@ -1062,8 +1100,29 @@ static NSUInteger nppLargeFileThreshold(void) {
     }
 
     if ([alert runModal] == NSAlertFirstButtonReturn) {
-        NSError *err;
-        [self loadFileAtPath:_filePath error:&err];
+        NSError *err = nil;
+        if (![self loadFileAtPath:_filePath error:&err]) {
+            // Record the mtime even on failure: the user asked for this reload
+            // and is told below that it did not happen, whereas re-prompting on
+            // every poll would trap them in a dialog loop.
+            _lastKnownModDate = mtime;
+            if (!([err.domain isEqualToString:NSCocoaErrorDomain] &&
+                  err.code == NSUserCancelledError)) {
+                NSAlert *failure = [[NSAlert alloc] init];
+                failure.messageText = [NSString stringWithFormat:@"Could not reload \"%@\"",
+                                       _filePath.lastPathComponent];
+                failure.informativeText = err.localizedDescription
+                                          ?: @"The file could not be read.";
+                [failure addButtonWithTitle:@"OK"];
+                [failure runModal];
+            }
+        }
+    } else {
+        // The user kept what is in the editor. Record the mtime so this same
+        // on-disk version is not reported as a new change on the next poll, and
+        // mute further prompts until those edits are saved or discarded.
+        _lastKnownModDate = mtime;
+        _externalChangeMuted = _isModified;
     }
     _externalChangePending = NO;
 }


### PR DESCRIPTION
### The bug

`-_pollExternalChange:` states its own contract in a comment:

> Dirty buffers always fall through to the prompt so unsaved changes are never discarded silently.

The condition below it does not honour that:

```objc
if (_monitoringMode || (updateSilently && !_isModified)) {
```

`_monitoringMode` short-circuits the `!_isModified` test. A monitored (tail -f) tab with unsaved edits is reloaded from disk **with no prompt at all**, and the edits are unrecoverable — the reload swaps in a new Scintilla document, so undo cannot bring them back.

A monitored buffer really can be dirty. `monitoringMode` is a plain ivar setter (`EditorView.mm:988`) and `-toggleMonitoring:` (`MainWindowController.mm:7194`) only flips it; nothing makes the document read-only, and ordinary editing sets `_isModified = YES` at `EditorView.mm:4633`. The CLI `-monitorFiles` and `-ro` flags are independent of each other too (`AppDelegate.mm:422`).

**Repro:** open a file, enable Monitoring, type a character, then append to the file from another program. The typing is gone, silently.

Requiring a clean buffer for *both* silent paths makes monitoring behave the way "Update silently" already does — a dirty buffer gets the existing *"Reloading will discard your unsaved changes"* prompt with its **Keep My Version** button.

### Second bug in the same method

`_lastKnownModDate` was advanced *before* the reload was attempted, and `loadFileAtPath:`'s `BOOL` return was discarded:

```objc
_lastKnownModDate = mtime;
...
NSError *err;
[self loadFileAtPath:_filePath error:&err];
```

So a load that never happened was recorded as one that had. A transient read error lost that revision **permanently**: the recorded mtime already matched the file, so no later poll ever reported it and the tab silently kept stale content.

`loadFileAtPath:` records `_lastKnownModDate` itself on success (`EditorView.mm:670`), so the early assignment is removed and each failure path now decides deliberately — silent failure retries, a cancelled large-file warning is recorded as the decision it is, declining is recorded, and a reload the user asked for that fails now says so instead of the dialog just closing with nothing happening.

### Two consequences handled rather than left to bite

Prompting where nothing prompted before creates two traps, both found by an independent review pass:

- **Prompt storm.** Answering *Keep My Version* records that mtime — but a monitored tab watches something that keeps growing, so the next append has a newer mtime and re-raises the same dialog a second later, with no answer that makes it stop. Keeping your version now mutes further prompts for that file until the edits are saved or discarded. This applies to the plain File Status Auto-Detection path too, which had the same trap already.
- **Infinite failing read.** Leaving `_lastKnownModDate` alone on failure is what makes a transient error recover, but a persistent one (permissions, a network volume that went away) would mean a failing read every second for as long as the tab is open. It now gives up after three attempts.

### Verification

- `ninja`: 0 errors, links and code-signs.
- Reviewed by an independent second model, which confirmed a monitored buffer can genuinely become dirty, that the clean tail -f path is unaffected, that `_externalChangePending` is cleared on every new return path, and that the large-file cancel really does return `NSCocoaErrorDomain` / `NSUserCancelledError`. The two traps above are its findings, fixed here.

Note this targets the data loss only. Windows Notepad++ makes monitored documents read-only, which would prevent the situation arising at all; that is a larger change (it has to interact with the user's own Read-Only toggle and the session-persisted `userReadOnly` flag) and is left as a follow-up.
