### PR TITLE
Fix word completion on documents containing non-ASCII text

### DIFF
--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -5895,8 +5895,21 @@ static const unsigned int kSCI_GetBidirectional = 2708;
 
     static const NSInteger kScanWindow = 500000;
     sptr_t docLen    = [sci message:SCI_GETLENGTH];
-    sptr_t scanStart = MAX(0, wordStart - kScanWindow);
-    sptr_t scanEnd   = MIN(docLen, pos + kScanWindow);
+    // Snap the window to line boundaries. wordStart ± kScanWindow is an arbitrary
+    // byte offset that can land in the middle of a UTF-8 sequence, and a range
+    // starting or ending on a partial character does not decode as UTF-8 — the
+    // NSString below comes back nil and completion silently stops working for the
+    // rest of the document. Line starts and line ends are always character
+    // boundaries.
+    sptr_t rawStart  = MAX(0, wordStart - kScanWindow);
+    sptr_t rawEnd    = MIN(docLen, pos + kScanWindow);
+    sptr_t scanStart = [sci message:SCI_POSITIONFROMLINE
+                             wParam:(uptr_t)[sci message:SCI_LINEFROMPOSITION
+                                                   wParam:(uptr_t)rawStart]];
+    sptr_t scanEnd   = [sci message:SCI_GETLINEENDPOSITION
+                             wParam:(uptr_t)[sci message:SCI_LINEFROMPOSITION
+                                                   wParam:(uptr_t)rawEnd]];
+    if (scanEnd < pos) scanEnd = MIN(docLen, pos);
     sptr_t scanLen   = scanEnd - scanStart;
     if (scanLen <= 0 || wordStart < scanStart) { if (beep) NSBeep(); return; }
 
@@ -5911,18 +5924,33 @@ static const unsigned int kSCI_GetBidirectional = 2708;
                                                   freeWhenDone:YES];
     if (!scanText) { free(buf); if (beep) NSBeep(); return; }
 
-    NSUInteger prefixOffset = (NSUInteger)(wordStart - scanStart);
-    if (prefixOffset + (NSUInteger)prefixLen > scanText.length) {
-        if (beep) NSBeep(); return;
-    }
-    NSString *prefix = [scanText substringWithRange:NSMakeRange(prefixOffset,
-                                                                (NSUInteger)prefixLen)];
+    // Read the prefix out of the document instead of indexing scanText with
+    // (wordStart - scanStart). Scintilla positions count UTF-8 bytes while
+    // scanText is an NSString indexed in UTF-16 units, so that delta is only
+    // correct while everything ahead of the caret is ASCII. One accented or CJK
+    // character earlier in the window makes the byte offset overshoot: either the
+    // bounds check trips and completion quietly stops, or a prefix is lifted from
+    // the wrong place and the popup offers words matching something the user
+    // never typed — accepting one then replaces prefixLen bytes before the caret
+    // with it, writing wrong text into the document.
+    char *prefixBuf = (char *)malloc((size_t)prefixLen + 1);
+    if (!prefixBuf) { if (beep) NSBeep(); return; }
+    Sci_TextRangeFull prefixRange = { {(Sci_Position)wordStart, (Sci_Position)pos}, prefixBuf };
+    [sci message:SCI_GETTEXTRANGEFULL wParam:0 lParam:(sptr_t)&prefixRange];
+    prefixBuf[prefixLen] = '\0';
+    NSString *prefix = [[NSString alloc] initWithBytesNoCopy:prefixBuf
+                                                      length:(NSUInteger)prefixLen
+                                                    encoding:NSUTF8StringEncoding
+                                                freeWhenDone:YES];
+    if (!prefix) { free(prefixBuf); if (beep) NSBeep(); return; }
 
     NSMutableCharacterSet *wordCS = [[NSCharacterSet alphanumericCharacterSet] mutableCopy];
     [wordCS addCharactersInString:@"_"];
     NSMutableSet<NSString *> *wordSet = [NSMutableSet set];
     for (NSString *word in [scanText componentsSeparatedByCharactersInSet:wordCS.invertedSet]) {
-        if (word.length > (NSUInteger)prefixLen && [word hasPrefix:prefix])
+        // prefix.length, not prefixLen: the latter is a byte count and would
+        // wrongly reject candidates whose prefix is non-ASCII.
+        if (word.length > prefix.length && [word hasPrefix:prefix])
             [wordSet addObject:word];
     }
     [wordSet removeObject:prefix];


### PR DESCRIPTION
Another instance of this code base's recurring Scintilla-byte-offset vs NSString-UTF-16-index defect class, this time on a path that runs on **every keystroke**.

### The bug

`-_showWordCompletionWithMinPrefix:beepOnEmpty:` derived the typed prefix by indexing an `NSString` with a Scintilla position:

```objc
NSUInteger prefixOffset = (NSUInteger)(wordStart - scanStart);
if (prefixOffset + (NSUInteger)prefixLen > scanText.length) { if (beep) NSBeep(); return; }
NSString *prefix = [scanText substringWithRange:NSMakeRange(prefixOffset, (NSUInteger)prefixLen)];
```

`wordStart` and `scanStart` are UTF-8 **byte** offsets; `scanText` is indexed in **UTF-16 units**. The delta is only correct while every character in the scan window ahead of the caret is ASCII. Because a byte offset is always ≥ the corresponding UTF-16 offset, one accented or CJK character earlier in the window makes it overshoot, and both outcomes are wrong:

- the bounds check trips and **word completion silently stops working** for the rest of the document — the automatic path passes `beepOnEmpty:NO`, so there is no feedback at all; or
- it passes, and the prefix is lifted from the wrong place. The popup then lists words matching a prefix the user never typed, and accepting one makes Scintilla replace `prefixLen` bytes before the caret with it — **writing wrong text into the document**.

This is not a corner case: auto-completion is enabled by default (`kPrefAutoCompleteEnable` defaults to `@YES`) and `-handleCharAdded:` calls this on every alphanumeric keystroke. Any file with a non-ASCII comment, string literal or identifier above the caret is affected.

**Repro:** put `// Größe` (or any CJK text) at the top of a file, type a couple of word characters further down, and watch the suggestion list.

### Fix

Read the prefix out of the document with `SCI_GETTEXTRANGEFULL` over `{wordStart, pos}` — the idiom `SearchEngine.mm` and the rest of this code base already use for exactly this reason — instead of indexing `scanText` with a byte delta. Candidate lengths are then compared against `prefix.length` rather than the byte count `prefixLen`, which would otherwise wrongly reject candidates when the prefix itself is non-ASCII.

### Second byte-offset problem in the same method

```objc
sptr_t scanStart = MAX(0, wordStart - kScanWindow);
sptr_t scanEnd   = MIN(docLen, pos + kScanWindow);
```

`wordStart ± 500000` is an arbitrary byte offset that can land in the middle of a UTF-8 sequence. A range beginning or ending on a partial character does not decode as UTF-8, so `initWithBytesNoCopy:` returns `nil` and completion stops working entirely — in any file larger than the scan window that contains non-ASCII anywhere near the boundary.

Both ends are now snapped to line boundaries, which are always character boundaries.

`SCI_AUTOCSHOW`'s `wParam` is deliberately left as `prefixLen`: Scintilla wants a byte count there, and that one was already correct.

### Verification

`ninja`: 0 errors, links and code-signs.
