### PR TITLE
Stop Import Style Theme destroying the theme it replaces

### DIFF
--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -742,16 +742,78 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
     NSString *themesDir = NppConfigSubpath(@"themes");
     [fm createDirectoryAtPath:themesDir withIntermediateDirectories:YES attributes:nil error:nil];
 
-    NSInteger imported = 0;
+    // Clear scratch files a crash or a failed cleanup left behind: staging below
+    // names them ".<uuid>", so anything matching that and nothing else is ours.
+    for (NSString *name in [fm contentsOfDirectoryAtPath:themesDir error:nil]) {
+        if (![name hasPrefix:@"."]) continue;
+        if (![[NSUUID alloc] initWithUUIDString:[name substringFromIndex:1]]) continue;
+        [fm removeItemAtPath:[themesDir stringByAppendingPathComponent:name] error:nil];
+    }
+
+    NSInteger imported = 0, alreadyInstalled = 0;
+    NSMutableArray<NSString *> *failures = [NSMutableArray array];
+    NSString *firstFailureReason = nil;
+
     for (NSURL *url in panel.URLs) {
         NSString *destPath = [themesDir stringByAppendingPathComponent:url.lastPathComponent];
-        [fm removeItemAtPath:destPath error:nil]; // overwrite existing
-        if ([fm copyItemAtPath:url.path toPath:destPath error:nil]) {
+        NSURL    *destURL  = [NSURL fileURLWithPath:destPath];
+
+        // Picking a theme that already lives in themesDir used to delete the file
+        // and then fail the copy from it — destroying the theme outright. Source
+        // and destination being the same file means there is nothing to do.
+        if ([destURL.URLByResolvingSymlinksInPath.URLByStandardizingPath
+                isEqual:url.URLByResolvingSymlinksInPath.URLByStandardizingPath]) {
+            alreadyInstalled++;   // counted apart from imported: nothing was copied
+            continue;
+        }
+
+        // Stage the copy under a scratch name, then swap it in. The old code
+        // deleted the destination first, so any failed copy — unreadable source,
+        // full disk — left the user with neither the old theme nor the new one.
+        // The dot prefix and missing .xml suffix keep the scratch file out of the
+        // theme list if the app dies mid-import.
+        NSString *tmpPath = [themesDir stringByAppendingPathComponent:
+                             [@"." stringByAppendingString:[[NSUUID UUID] UUIDString]]];
+        NSError *err = nil;
+        if (![fm copyItemAtPath:url.path toPath:tmpPath error:&err]) {
+            [fm removeItemAtPath:tmpPath error:nil];
+            [failures addObject:url.lastPathComponent];
+            if (!firstFailureReason) firstFailureReason = err.localizedDescription;
+            continue;
+        }
+
+        BOOL replaced = [fm fileExistsAtPath:destPath]
+            ? [fm replaceItemAtURL:destURL
+                     withItemAtURL:[NSURL fileURLWithPath:tmpPath]
+                    backupItemName:nil
+                           options:0
+                  resultingItemURL:nil
+                             error:&err]
+            : [fm moveItemAtPath:tmpPath toPath:destPath error:&err];
+
+        if (replaced) {
             imported++;
+        } else {
+            [fm removeItemAtPath:tmpPath error:nil];
+            [failures addObject:url.lastPathComponent];
+            if (!firstFailureReason) firstFailureReason = err.localizedDescription;
         }
     }
 
-    if (imported > 0) {
+    // Silence used to be the only report of a failed import.
+    if (failures.count) {
+        NSAlert *a = [[NSAlert alloc] init];
+        a.messageText = [loc translate:@"Import Style Theme"];
+        NSString *list = [NSString stringWithFormat:
+            [loc translate:@"Could not import: %@"],
+            [failures componentsJoinedByString:@", "]];
+        a.informativeText = firstFailureReason.length
+            ? [NSString stringWithFormat:@"%@\n\n%@", list, firstFailureReason]
+            : list;
+        [a runModal];
+    }
+
+    if (imported > 0 || alreadyInstalled > 0) {
         // Open Style Configurator so user can select the newly imported theme
         [[StyleConfiguratorWindowController sharedController] showWindow:nil];
     }


### PR DESCRIPTION
### The bug

`-[AppDelegate importStyleTheme:]` deleted the destination before attempting the copy:

```objc
NSString *destPath = [themesDir stringByAppendingPathComponent:url.lastPathComponent];
[fm removeItemAtPath:destPath error:nil]; // overwrite existing
if ([fm copyItemAtPath:url.path toPath:destPath error:nil]) {
    imported++;
}
```

So any failed copy leaves the user with **neither** the old theme nor the new one, and the result is neither checked nor reported.

The worst case needs no I/O error at all. Selecting a theme that already lives in the themes directory makes source and destination the **same file**: the delete removes the source, and the copy that follows can only fail. Picking an installed theme in the open panel silently destroys it, with no alert — `imported` simply stays 0.

### The fix

- Same-file selection is resolved first: nothing to copy.
- Otherwise the copy is staged under a scratch name and swapped in with `replaceItemAtURL:` (Foundation's safe-save API, with the scratch item uniquely named beside the original as its contract recommends) only once the new file is safely on disk. The existing theme survives every failure path, including an unwritable themes directory, where staging fails before anything is touched.
- Files that could not be imported are named in an alert, with the first underlying `NSError` description, instead of being counted silently.
- A scratch file left behind by a crash or a failed cleanup is swept on the next import. The `.<uuid>` name is matched by *parsing* the UUID, so nothing else in the directory can be caught.
- A same-file selection is counted separately from real imports. It still opens the Style Configurator — that is what the user asked for — but is no longer reported internally as having imported something.

The scratch name has no `.xml` suffix, so `availableThemeNames` ignores it even if the app dies mid-import.

### Not covered

The XML is still not validated as a Nextpad++ theme, so an arbitrary XML file can replace an installed one and later parse as empty. That is pre-existing and felt out of scope here — happy to add it if you'd prefer.

### Testing

`ninja` clean, no new warnings in `AppDelegate.mm`.

The destructive path was established by reading, not by running it — I did not want to delete a theme to prove it. It is easy to confirm: pick any file from the themes directory itself in the import panel. Before this change the same-path `removeItemAtPath:` fires first and the file is gone; after it, the same-file branch returns without touching anything.
