### PR TITLE
Fix Cmd+F-key shortcuts taking effect only after a restart (#265)

### DIFF
--- a/src/AppDelegate.mm
+++ b/src/AppDelegate.mm
@@ -11,6 +11,7 @@
 #import "UserDefineLangManager.h"
 #import "NppLangsManager.h"
 #import "EditorView.h"
+#import "ShortcutMapperWindowController.h"
 
 // Files opened from a folder beyond this count trigger a confirmation.
 static const NSUInteger kFolderOpenConfirmThreshold = 20;
@@ -598,30 +599,7 @@ static const NSUInteger kFolderOpenConfirmThreshold = 20;
             hasCmd = YES; hasCtrl = NO;
         }
 
-        if (keyCode == 0) {
-            mi.keyEquivalent = @"";
-            mi.keyEquivalentModifierMask = 0;
-        } else {
-            NSEventModifierFlags mods = 0;
-            if (hasCmd)   mods |= NSEventModifierFlagCommand;
-            if (hasCtrl)  mods |= NSEventModifierFlagControl;
-            if (hasAlt)   mods |= NSEventModifierFlagOption;
-            if (hasShift) mods |= NSEventModifierFlagShift;
-
-            NSString *key = @"";
-            if (keyCode >= 'A' && keyCode <= 'Z')
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-            else if (keyCode >= '0' && keyCode <= '9')
-                key = [NSString stringWithFormat:@"%c", (char)keyCode];
-            else if (keyCode >= 112 && keyCode <= 123) {
-                unichar fk = NSF1FunctionKey + (keyCode - 112);
-                key = [NSString stringWithCharacters:&fk length:1];
-            } else
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-
-            mi.keyEquivalent = key;
-            mi.keyEquivalentModifierMask = mods;
-        }
+        NppApplyShortcutToMenuItem(mi, keyCode, hasCmd, hasCtrl, hasAlt, hasShift);
     };
 
     NSInteger totalApplied = 0;

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -5559,25 +5559,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
                 hasCmd = YES; hasCtrl = NO;
             }
 
-            NSEventModifierFlags mods = 0;
-            if (hasCmd)   mods |= NSEventModifierFlagCommand;
-            if (hasCtrl)  mods |= NSEventModifierFlagControl;
-            if (hasAlt)   mods |= NSEventModifierFlagOption;
-            if (hasShift) mods |= NSEventModifierFlagShift;
-
-            NSString *key = @"";
-            if (keyCode >= 'A' && keyCode <= 'Z')
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-            else if (keyCode >= '0' && keyCode <= '9')
-                key = [NSString stringWithFormat:@"%c", (char)keyCode];
-            else if (keyCode >= 112 && keyCode <= 123) {
-                unichar fk = NSF1FunctionKey + (keyCode - 112);
-                key = [NSString stringWithCharacters:&fk length:1];
-            } else
-                key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
-
-            item.keyEquivalent = key;
-            item.keyEquivalentModifierMask = mods;
+            NppApplyShortcutToMenuItem(item, keyCode, hasCmd, hasCtrl, hasAlt, hasShift);
         }
 
         [macroMenu insertItem:item atIndex:insertIdx++];
@@ -5635,21 +5617,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
                 hasCmd = YES; hasCtrl = NO;
             }
 
-            NSEventModifierFlags mods = 0;
-            if (hasCmd)   mods |= NSEventModifierFlagCommand;
-            if (hasCtrl)  mods |= NSEventModifierFlagControl;
-            if (hasAlt)   mods |= NSEventModifierFlagOption;
-            if (hasShift) mods |= NSEventModifierFlagShift;
-
-            unichar kc = 0;
-            if (keyCode >= 112 && keyCode <= 123) kc = NSF1FunctionKey + (keyCode - 112);
-            else if (keyCode >= 'A' && keyCode <= 'Z') kc = keyCode + 32;
-            else if (keyCode >= '0' && keyCode <= '9') kc = keyCode;
-            else kc = keyCode;
-            if (kc) {
-                item.keyEquivalent = [NSString stringWithCharacters:&kc length:1];
-                item.keyEquivalentModifierMask = mods;
-            }
+            NppApplyShortcutToMenuItem(item, keyCode, hasCmd, hasCtrl, hasAlt, hasShift);
         }
 
         [runMenu insertItem:item atIndex:insertIdx++];

--- a/src/ShortcutMapperWindowController.h
+++ b/src/ShortcutMapperWindowController.h
@@ -6,6 +6,24 @@ NS_ASSUME_NONNULL_BEGIN
 /// refresh menu accelerators and Scintilla key bindings.
 extern NSNotificationName const NPPShortcutsChangedNotification;
 
+/// Install a shortcuts.xml key assignment on a menu item.
+///
+/// Shortcuts are stored Windows-style — a virtual-key code plus four modifier
+/// flags — and have to be translated into the (keyEquivalent, modifierMask)
+/// pair AppKit wants. Four places need that translation: the Shortcut Mapper,
+/// which updates the live menus the moment the user saves; AppDelegate, which
+/// replays the whole file at launch; and MainWindowController's macro and
+/// Run-command menu rebuilds. They must agree, or a shortcut behaves
+/// differently before and after a restart (issue #265) — so the mapping lives
+/// here once rather than in four copies that drift apart.
+///
+/// Callers are responsible for the legacy `Ctrl=yes` with no `Cmd` attribute
+/// fixup before calling; that concerns reading the file, not the key mapping.
+///
+/// A `keyCode` of 0 clears the item's shortcut.
+void NppApplyShortcutToMenuItem(NSMenuItem *mi, NSUInteger keyCode,
+                                BOOL hasCmd, BOOL hasCtrl, BOOL hasAlt, BOOL hasShift);
+
 /// The 5 tabs of the Shortcut Mapper, matching Windows NPP.
 typedef NS_ENUM(NSInteger, ShortcutMapperTab) {
     ShortcutMapperTabMainMenu = 0,

--- a/src/ShortcutMapperWindowController.mm
+++ b/src/ShortcutMapperWindowController.mm
@@ -1222,40 +1222,47 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     [[NSNotificationCenter defaultCenter] postNotificationName:NPPShortcutsChangedNotification object:nil];
 }
 
-- (void)_applyShortcutEntry:(ShortcutEntry *)e toMenuItem:(NSMenuItem *)mi {
-    if (e.keyCode == 0) {
+void NppApplyShortcutToMenuItem(NSMenuItem *mi, NSUInteger keyCode,
+                               BOOL hasCmd, BOOL hasCtrl, BOOL hasAlt, BOOL hasShift) {
+    if (keyCode == 0) {
         mi.keyEquivalent = @"";
         mi.keyEquivalentModifierMask = 0;
         return;
     }
     NSEventModifierFlags mods = 0;
-    if (e.hasCmd)   mods |= NSEventModifierFlagCommand;
-    if (e.hasCtrl)  mods |= NSEventModifierFlagControl;
-    if (e.hasAlt)   mods |= NSEventModifierFlagOption;
-    if (e.hasShift) mods |= NSEventModifierFlagShift;
+    if (hasCmd)   mods |= NSEventModifierFlagCommand;
+    if (hasCtrl)  mods |= NSEventModifierFlagControl;
+    if (hasAlt)   mods |= NSEventModifierFlagOption;
+    if (hasShift) mods |= NSEventModifierFlagShift;
 
     NSString *key = @"";
-    if (e.keyCode >= 'A' && e.keyCode <= 'Z') {
-        key = [[NSString stringWithFormat:@"%c", (char)e.keyCode] lowercaseString];
-    } else if (e.keyCode >= '0' && e.keyCode <= '9') {
-        key = [NSString stringWithFormat:@"%c", (char)e.keyCode];
-    } else if (e.keyCode >= 112 && e.keyCode <= 123) {
-        unichar fk = NSF1FunctionKey + (e.keyCode - 112);
+    if (keyCode >= 'A' && keyCode <= 'Z') {
+        key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString];
+    } else if (keyCode >= '0' && keyCode <= '9') {
+        key = [NSString stringWithFormat:@"%c", (char)keyCode];
+    } else if (keyCode >= 112 && keyCode <= 123) {
+        // F1–F12. The modifiers are kept exactly as the user chose them: an
+        // F-key is a complete shortcut on its own, but ⌘F8 is equally valid and
+        // is what the mapper shows and what shortcuts.xml stores.
+        unichar fk = NSF1FunctionKey + (keyCode - 112);
         key = [NSString stringWithCharacters:&fk length:1];
-        mods &= ~NSEventModifierFlagCommand; // function keys don't need Cmd implicit
     } else {
         // Special keys
-        switch (e.keyCode) {
+        switch (keyCode) {
             case 8:  key = [NSString stringWithFormat:@"%C", (unichar)NSBackspaceCharacter]; break;
             case 9:  key = @"\t"; break;
             case 13: key = @"\r"; break;
             case 27: key = [NSString stringWithFormat:@"%C", (unichar)0x1B]; break;
             case 46: key = [NSString stringWithFormat:@"%C", (unichar)NSDeleteCharacter]; break;
-            default: key = [[NSString stringWithFormat:@"%c", (char)e.keyCode] lowercaseString]; break;
+            default: key = [[NSString stringWithFormat:@"%c", (char)keyCode] lowercaseString]; break;
         }
     }
     mi.keyEquivalent = key;
     mi.keyEquivalentModifierMask = mods;
+}
+
+- (void)_applyShortcutEntry:(ShortcutEntry *)e toMenuItem:(NSMenuItem *)mi {
+    NppApplyShortcutToMenuItem(mi, e.keyCode, e.hasCmd, e.hasCtrl, e.hasAlt, e.hasShift);
 }
 
 // Resolve a plugin menu item by (pluginName, commandID) instead of by


### PR DESCRIPTION
Fixes #265.

### The bug

Assigning a shortcut like <kbd>⌘F8</kbd> in the Shortcut Mapper does nothing until the app is restarted, after which it works.

### Cause

Two code paths translate a `shortcuts.xml` entry (a Windows virtual-key code plus four modifier flags) into the `keyEquivalent`/`keyEquivalentModifierMask` pair AppKit needs, and they had drifted apart:

| | applies when | F1–F12 + Command |
|---|---|---|
| `-[ShortcutMapperWindowController _applyShortcutEntry:toMenuItem:]` | immediately, when the user saves in the mapper | cleared the Command bit → installed bare <kbd>F8</kbd> |
| `applyOverride` in `-[AppDelegate _loadShortcutOverrides]` | at launch, replaying the whole file | kept Command → installed <kbd>⌘F8</kbd> |

Hence "only works after a restart". The `mods &= ~NSEventModifierFlagCommand;` line dates to the original Shortcut Mapper commit; nothing depends on it. `hasCmd` is the user's own checkbox (`ShortcutMapperWindowController.mm:1113`) and is persisted faithfully as the `Cmd` attribute, so clearing it contradicted both the UI and the saved file.

I checked that no default relied on the strip: `resources/shortcuts.xml` contains no F-key entry at all, the Scintilla defaults table has none, and the one built-in ⌘+F-key shortcut — Toggle Bookmark <kbd>⌘F2</kbd>, `MenuBuilder.mm:557` — sets Command explicitly.

### Second, unreported divergence

The same two paths also disagreed about virtual-key **46**, which is Delete in the mapper's key tables (`.` is 190). The live path mapped it to `NSDeleteCharacter`; the launch path had no case for it and fell through to a `%c` cast, so a shortcut assigned to <kbd>Delete</kbd> silently became <kbd>.</kbd> after a restart.

### The fix

Rather than patch the copies, the mapping now lives in one shared function, `NppApplyShortcutToMenuItem`, declared in `ShortcutMapperWindowController.h`. Both paths call it, so they cannot drift again.

An independent review found **two further copies** of the same mapping — the macro and Run-command menu rebuilds in `MainWindowController.mm` — which still carried the virtual-key 46 bug. Both now call the shared function too, and the header comment names all four callers.

### Testing

Builds clean (`ninja`, 0 errors). Behaviour is unchanged for every shortcut that is not an F-key with Command, or the Delete key.
