### PR TITLE
Keep save-prompt keyboard shortcuts working when the buttons are translated (#294)

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -8573,11 +8573,22 @@ typedef NS_ENUM(NSInteger, NppBatchCloseDecision) {
     NppLocalizer *loc = [NppLocalizer shared];
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = [NSString stringWithFormat:[loc translate:@"Save '%@' before closing?"], ed.displayName];
+    // These titles are translated, and AppKit's automatic key equivalents match on
+    // the ENGLISH title — so in a non-English build "Don't Save" and "Cancel" had
+    // no shortcut (issue #294). The default button gets Return whatever it is
+    // called, so Save is already reachable and needs nothing here.
     [alert addButtonWithTitle:[loc translate:@"Save"]];        // NSAlertFirstButtonReturn
-    [alert addButtonWithTitle:[loc translate:@"Don't Save"]];  // NSAlertSecondButtonReturn
-    if (allowAll)
+    NSButton *dontSave = [alert addButtonWithTitle:[loc translate:@"Don't Save"]]; // NSAlertSecondButtonReturn
+    dontSave.keyEquivalent = @"d";
+    dontSave.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+    if (allowAll) {
+        // Deliberately no key equivalent. The obvious choice, ⇧⌘D, is unsafe here:
+        // this alert is usually reached by Close All (⇧⌘W), which leaves Shift
+        // under the user's finger, so reaching for ⌘D would discard every
+        // remaining modified document instead of one. Bulk discard stays click-only.
         [alert addButtonWithTitle:[loc translate:@"Don't Save All"]]; // NSAlertThirdButtonReturn
-    [alert addButtonWithTitle:[loc translate:@"Cancel"]];      // Third (or fourth) button
+    }
+    [alert addButtonWithTitle:[loc translate:@"Cancel"]].keyEquivalent = @"\033"; // Third (or fourth) button
 
     NSModalResponse r = [alert runModal];
     if (r == NSAlertFirstButtonReturn) {            // Save

--- a/src/ProjectPanel.mm
+++ b/src/ProjectPanel.mm
@@ -738,9 +738,14 @@ static void _PPCollectFiles(_ProjectItem *item, NSMutableArray<NSString *> *out)
     NSAlert *alert = [[NSAlert alloc] init];
     alert.messageText = [loc translate:@"The workspace was modified."];
     alert.informativeText = [loc translate:@"Do you want to save changes?"];
+    // Explicit key equivalents: AppKit's automatic ones match on the English
+    // button title, so a translated alert would have no keyboard path at all
+    // (issue #294). The first button is the default and gets Return regardless.
     [alert addButtonWithTitle:[loc translate:@"Save"]];
-    [alert addButtonWithTitle:[loc translate:@"Don't Save"]];
-    [alert addButtonWithTitle:[loc translate:@"Cancel"]];
+    NSButton *dontSave = [alert addButtonWithTitle:[loc translate:@"Don't Save"]];
+    dontSave.keyEquivalent = @"d";
+    dontSave.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+    [alert addButtonWithTitle:[loc translate:@"Cancel"]].keyEquivalent = @"\033";
     NSModalResponse resp = [alert runModal];
     if (resp == NSAlertFirstButtonReturn) {
         if (ws.filePath)

--- a/src/TabManager.mm
+++ b/src/TabManager.mm
@@ -123,9 +123,17 @@
         NSAlert *alert = [[NSAlert alloc] init];
         alert.messageText = [NSString stringWithFormat:@"Save changes to \"%@\"?", editor.displayName];
         alert.informativeText = @"Your changes will be lost if you don't save them.";
+        // Key equivalents are assigned explicitly rather than left to AppKit.
+        // AppKit does supply them, but it matches on the ENGLISH button title —
+        // "Don't Save" gets ⌘D and "Cancel" gets ⎋, while a translated title
+        // gets nothing at all. Setting them here keeps the keyboard path working
+        // if these strings are ever localized (issue #294). The first button is
+        // the default and gets Return whatever it is called, so Save needs none.
         [alert addButtonWithTitle:@"Save"];
-        [alert addButtonWithTitle:@"Don't Save"];
-        [alert addButtonWithTitle:@"Cancel"];
+        NSButton *dontSave = [alert addButtonWithTitle:@"Don't Save"];
+        dontSave.keyEquivalent = @"d";
+        dontSave.keyEquivalentModifierMask = NSEventModifierFlagCommand;
+        [alert addButtonWithTitle:@"Cancel"].keyEquivalent = @"\033";
         NSModalResponse resp = [alert runModal];
 
         if (resp == NSAlertFirstButtonReturn) {


### PR DESCRIPTION
Addresses #294.

### What I measured first

AppKit already assigns an alert's key equivalents automatically — but it matches on the **English button title**. I compiled a standalone AppKit probe that builds `NSAlert`s and prints each button's resulting `keyEquivalent`:

| buttons | Save | Don't Save | Don't Save All | Cancel |
|---|---|---|---|---|
| English | <kbd>↩</kbd> | <kbd>⌘D</kbd> | — | <kbd>⎋</kbd> |
| translated (German) | <kbd>↩</kbd> | **none** | **none** | **none** |

So on an English build the reporter's request is already satisfied — the shortcuts exist, they are just undiscoverable, since macOS does not show mnemonics on alert buttons the way Windows does.

The genuine defects are the other two rows: **a non-English build has no way to reach Don't Save or Cancel from the keyboard**, and **"Don't Save All" has no shortcut in any language**. Two of the three affected alerts run their titles through `NppLocalizer`.

### The fix

Assign the equivalents explicitly so they no longer depend on the button text:

- **Don't Save** → <kbd>⌘D</kbd>
- **Cancel** → <kbd>⎋</kbd>
- **Save** → left alone; the default button gets <kbd>↩</kbd> whatever it is called.

On an English build this changes nothing observable — it pins the values AppKit was already choosing.

Sites: `-[TabManager closeEditor:]` (the alert in the issue's screenshot), `-[MainWindowController _promptBatchSaveBeforeClose:allowAll:]`, and `-[ProjectPanel _promptSaveDirtyWorkspace:]`.

### Why "Don't Save All" deliberately gets none

The obvious choice, <kbd>⇧⌘D</kbd>, is unsafe in this specific alert. It is normally reached via **Close All (<kbd>⇧⌘W</kbd>)**, which leaves Shift under the user's finger — so reaching for the <kbd>⌘D</kbd> they just learned would discard *every* remaining modified document instead of one, with no further confirmation. Bulk discard stays click-only. (Caught in review; the first version of this patch did bind ⇧⌘D.)

### Note on the original request

The issue asks for bare <kbd>S</kbd> / <kbd>N</kbd> / <kbd>C</kbd>, which is the Windows mnemonic convention. This implements the macOS equivalents instead, which is what the rest of the app and every system alert use. Happy to change it if you would rather match Windows here.

### Testing

Builds clean (`ninja`, 0 errors). Verified with the probe against an unpatched control: with translated titles the patched alert yields <kbd>↩</kbd>/<kbd>⌘D</kbd>/<kbd>⎋</kbd> where the control yields only <kbd>↩</kbd>. Button order — and therefore the `NSAlertFirstButtonReturn`/`Second`/`Third` mapping both call sites depend on — is untouched.
