### PR TITLE
Add View > Hide Toolbar menu item

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -6431,6 +6431,13 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     if (action == @selector(resetView:))
         return vHasTabs || hHasTabs;
 
+    // Hide Toolbar — checked while the toolbar IS hidden. Disabled in Post-It
+    // mode, which removes the toolbar object altogether.
+    if (action == @selector(toggleToolbar:)) {
+        NSToolbar *tb = self.window.toolbar;
+        [mi setState:(tb && !tb.isVisible) ? NSControlStateValueOn : NSControlStateValueOff];
+        return tb != nil;
+    }
     // Always on Top checkmark
     if (action == @selector(toggleAlwaysOnTop:)) {
         [mi setState:(self.window.level == NSFloatingWindowLevel) ? NSControlStateValueOn : NSControlStateValueOff];
@@ -7055,6 +7062,23 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
 - (void)unfoldLevel7:(id)s { [[self currentEditor] unfoldLevel7:s]; }
 - (void)unfoldLevel8:(id)s { [[self currentEditor] unfoldLevel8:s]; }
 - (void)unfoldCurrentLevel:(id)sender { [[self currentEditor] unfoldCurrentLevel:sender]; }
+
+#pragma mark - View: Toolbar visibility
+
+// View > Hide Toolbar. The pref is written immediately so the toolbar
+// comes back in the same state after a crash or a Force Quit — saveWindowFrame
+// only runs on a clean shutdown.
+- (void)toggleToolbar:(id)sender {
+    NSToolbar *tb = self.window.toolbar;
+    if (!tb) return;   // Post-It mode removes the toolbar entirely
+    BOOL nowVisible = !tb.isVisible;
+    tb.visible = nowVisible;
+    [[NSUserDefaults standardUserDefaults] setBool:nowVisible forKey:kPrefToolbarVisible];
+    // Keep the saved state used to restore Post-It / Distraction Free in sync,
+    // so leaving those modes doesn't resurrect a toolbar the user just hid.
+    _postItSavedToolbarVisible = nowVisible;
+    _savedToolbarVisible       = nowVisible;
+}
 
 #pragma mark - Window: Always on Top
 

--- a/src/MenuBuilder.mm
+++ b/src/MenuBuilder.mm
@@ -579,7 +579,13 @@ static NSMenu *buildLanguageMenu() {
 
     [viewMenu addItem:itemMod(@"Command Palette…", @selector(showCommandPalette:), @"p",
                               NSEventModifierFlagCommand | NSEventModifierFlagShift)];
-    [viewMenu addItem:item(@"Toggle Toolbar", @selector(toggleToolbarShown:), @"")];
+    // Checked when the toolbar is hidden — the checkmark reads as "hiding is on",
+    // matching the Show Symbol > "Hide Line Marks" item below. ⌥⌘T is the
+    // macOS-standard toolbar shortcut. Handled by MainWindowController (not
+    // NSWindow's toggleToolbarShown:) so the choice is persisted to
+    // kPrefToolbarVisible right away.
+    [viewMenu addItem:itemMod(@"Hide Toolbar", @selector(toggleToolbar:), @"t",
+                              NSEventModifierFlagCommand | NSEventModifierFlagOption)];
     addSep(viewMenu);
     [viewMenu addItem:item(@"Always on Top", @selector(toggleAlwaysOnTop:), @"")];
     [viewMenu addItem:itemMod(@"Toggle Full Screen Mode", @selector(toggleFullScreen:), @"f",


### PR DESCRIPTION

<img width="1001" height="1004" alt="image" src="https://github.com/user-attachments/assets/4301a152-e325-4aa7-8656-b242bd847437" />

<img width="872" height="963" alt="image" src="https://github.com/user-attachments/assets/55249f94-7111-42da-89e9-02539642473c" />


## What this does

Adds a **View > Hide Toolbar** item (⌥⌘T) so the toolbar can be hidden from the menu bar. The checkmark shows while the toolbar is hidden.

## Changes

- `MenuBuilder.mm` — renamed to "Hide Toolbar", bound to `-toggleToolbar:`, with the macOS-standard ⌥⌘T shortcut (nothing else in the menu tree used `T`).
- `MainWindowController.mm` — new `-toggleToolbar:` flips `window.toolbar.visible` and writes `kPrefToolbarVisible` immediately. It also syncs `_postItSavedToolbarVisible` / `_savedToolbarVisible`, so leaving Post-It or Distraction Free mode doesn't bring back a toolbar the user just hid.
- `validateUserInterfaceItem:` — checkmark while the toolbar is hidden, reading the same way as "Hide Line Marks (Bookmarks)" further down the menu. Disabled in Post-It mode, which sets `window.toolbar = nil`.

The selector name matches the `toggleToolbar:` entry already present in `NppApplication`'s macro-recording blacklist.

## Testing

- Builds clean in Debug and Release (universal binary).
- Launched with the toolbar hidden: the editor repins to `contentLayoutGuide`, no layout gap or constraint errors.

