### PR TITLE
Refresh the tab that holds the saved editor, not the primary view's (#321)

### DIFF
--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -4870,7 +4870,7 @@ static void removeMacroFromShortcutsXML(NSString *name) {
     if (!ed.filePath) { [self saveDocumentAs:sender]; return; }
     NSError *err;
     if (![ed saveError:&err]) [[NSAlert alertWithError:err] runModal];
-    [self refreshCurrentTab];
+    [self refreshTabsForEditor:ed];
 }
 
 - (void)saveDocumentAs:(id)sender {
@@ -4883,7 +4883,10 @@ static void removeMacroFromShortcutsXML(NSString *name) {
             NSError *err;
             if (![ed saveToPath:panel.URL.path error:&err])
                 [[NSAlert alertWithError:err] runModal];
-            [self refreshCurrentTab];
+            // ed, not -currentEditor: the panel is modeless, so the active pane
+            // can change while it is open, and the tab that needs repainting is
+            // the one holding the editor this save actually wrote.
+            [self refreshTabsForEditor:ed];
         }
     }];
 }
@@ -11084,11 +11087,36 @@ static NSString *languageDisplayName(NSString *langCode) {
                                 inView:_statusBar];
 }
 
-- (void)refreshCurrentTab {
-    [_tabManager refreshCurrentTabTitle];
+/// Repaint every tab that shows `editor`, in whichever pane owns it.
+///
+/// Addressing the tab by editor rather than by "the current tab of the primary
+/// manager" matters in split view for two reasons. An editor moved into a pane
+/// is owned by _subTabManagerH/V, so refreshing _tabManager repainted an
+/// unrelated primary tab, if any, and left the pane's own tab stale — the
+/// tab kept reading "new N" after Save As, and kept its modified dot after
+/// Save, while -updateTitle (which goes through -currentEditor) showed the new
+/// name. A *cloned* editor additionally has a sibling in the other pane sharing
+/// its document, and -[EditorView saveToPath:] propagates filePath and modified
+/// state to that sibling, so its tab goes stale at the same moment and has to
+/// be repainted too.
+///
+/// Note cloneSibling holds a single peer, so a buffer cloned into both panes is
+/// only partly reached here. That is the existing clone model, not a limit of
+/// this method.
+- (void)refreshTabsForEditor:(EditorView *)editor {
+    if (!editor) return;
+    EditorView *sibling = editor.cloneSibling;
+    for (TabManager *mgr in @[_tabManager, _subTabManagerH, _subTabManagerV]) {
+        [mgr refreshTitleForEditor:editor];
+        if (sibling) [mgr refreshTitleForEditor:sibling];
+    }
     [self updateTitle];
     if (_docListPanel && [_sidePanelHost hasPanel:_docListPanel])
         [_docListPanel refreshModifiedStates];
+}
+
+- (void)refreshCurrentTab {
+    [self refreshTabsForEditor:[self currentEditor]];
 }
 
 - (void)saveWindowFrame {

--- a/src/TabManager.h
+++ b/src/TabManager.h
@@ -57,6 +57,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// Refresh all tab titles and modified icons (e.g. after Save All).
 - (void)refreshAllTabTitles;
 
+/// Refresh the tab showing `editor`, wherever it sits in this manager. Does
+/// nothing if this manager does not own it, so a caller can offer the same
+/// editor to every manager and let the owner respond.
+- (void)refreshTitleForEditor:(EditorView *)editor;
+
 /// Select tab by index programmatically (fires delegate).
 - (void)selectTabAtIndex:(NSInteger)index;
 

--- a/src/TabManager.mm
+++ b/src/TabManager.mm
@@ -179,6 +179,13 @@
         [_tabBar setTitle:_editors[i].displayName modified:_editors[i].isModified atIndex:i];
 }
 
+- (void)refreshTitleForEditor:(EditorView *)editor {
+    if (!editor) return;
+    NSInteger idx = [_editors indexOfObject:editor];
+    if (idx == NSNotFound) return;
+    [_tabBar setTitle:editor.displayName modified:editor.isModified atIndex:idx];
+}
+
 - (void)selectTabAtIndex:(NSInteger)index {
     if (index < 0 || index >= (NSInteger)_editors.count) return;
     [self activateTabAtIndex:index];


### PR DESCRIPTION
Fixes #321.

## Problem

With a document in a split pane, File > Save As wrote the file but left that
pane's tab reading `new N`, and a plain File > Save left its modified dot on.
The primary view was unaffected.

Reproduced on `main`, with the primary view as the control:

| | tab after saving |
|---|---|
| new tab → *Move to Other Vertical View* → Save As `x.txt` | still `new 3`, still marked modified |
| new tab in the primary view → Save As `y.txt` | renames to `y.txt`, dot clears |

## Cause

`-refreshCurrentTab` repainted `[_tabManager refreshCurrentTabTitle]` — the
primary manager's own selected tab — while every caller acts on
`-currentEditor`, which comes from `_activeTabManager`. With the editor owned by
`_subTabManagerH`/`_subTabManagerV` the repaint landed on an unrelated primary
tab and the pane's own tab was never touched.

The same method makes it visible: `-updateTitle` on the next line does go
through `-currentEditor`, so the **window title showed the new filename while
the tab showed the old one**.

The two rename paths (`~:8463`, `~:8522`) already use `_activeTabManager`, and
`-saveAllDocuments:` already refreshes all three managers. Only this path did
not.

## Fix

Switching to `_activeTabManager` alone would still miss clones: a cloned editor
has a sibling in the other pane sharing its document, and `-[EditorView
saveToPath:]` propagates `filePath` and modified state to it, so both tabs go
stale at the same moment. Repainting only the active pane would move the
staleness from one tab to the other rather than remove it.

So the tab is addressed by editor identity instead:

- `-[TabManager refreshTitleForEditor:]` — repaints that editor's tab, no-op
  unless this manager owns it, so a caller can offer the same editor to every
  manager and let the owner respond.
- `-[MainWindowController refreshTabsForEditor:]` — offers the editor and its
  `cloneSibling` to all three managers, then does the `-updateTitle` and
  Document List work `-refreshCurrentTab` used to do.
- `-saveDocument:` and the `-saveDocumentAs:` completion block pass the editor
  they captured rather than asking for the current one. The save panel is
  modeless, so the active pane can change while it is open.

`-refreshCurrentTab` now forwards `-currentEditor`, keeping `-editorCursorMoved:`
unchanged in behaviour.

## Verification

Built and exercised on the resulting binary:

- moved editor: Save As renames the pane's tab; Save clears its dot
- primary view: unchanged (control)
- cloned editor: editing in one pane marks both tabs modified; saving from
  **either** pane renames both tabs and clears both dots
- caret movement across both panes: no crash, no diagnostic report

## Known limits, deliberately not addressed here

`cloneSibling` stores a single peer, so a buffer cloned into *both* panes is
only partly reached. That is the existing clone model rather than a limit of
this change, and nothing is worse than before it.

`-refreshCurrentTab` now costs a linear lookup per caret move instead of a
direct index access. The repaint already triggered by the same event dominates
it; a second, cheaper code path for the caret case seemed a worse trade than
one uniform one.
