### PR TITLE
Added Feature for Displaying Zoom level Indication(#310)

### DIFF
--- a/src/EditorView.h
+++ b/src/EditorView.h
@@ -15,6 +15,9 @@ extern NSNotificationName const EditorViewDidGainFocusNotification;
 /// invocations gated to the panel-visible state (issue #76).
 extern NSNotificationName const EditorViewDidSaveNotification;
 
+/// Posted when an editor's zoom level changes (SCN_ZOOM). Object is the EditorView.
+extern NSNotificationName const EditorViewZoomDidChangeNotification;
+
 /// Wraps ScintillaView and provides Nextpad++-style editor functionality.
 @interface EditorView : NSView <ScintillaNotificationProtocol>
 
@@ -65,6 +68,12 @@ extern NSNotificationName const EditorViewDidSaveNotification;
 
 // YES when in overwrite (OVR) mode, NO for normal insert (INS) mode.
 @property (nonatomic, readonly) BOOL isOverwriteMode;
+
+/// Live zoom points from Scintilla (SCI_GETZOOM). 0 is default 100%.
+@property (nonatomic, readonly) NSInteger zoomLevel;
+
+/// Live zoom percentage (e.g. 100 for 100%, 110 for 110%, etc.).
+@property (nonatomic, readonly) NSInteger zoomPercentage;
 
 // Word wrap — stored per-editor tab.
 @property (nonatomic) BOOL wordWrapEnabled;

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -26,6 +26,7 @@ NSNotificationName const EditorViewCursorDidMoveNotification = @"EditorViewCurso
 NSNotificationName const EditorViewDidGainFocusNotification  = @"EditorViewDidGainFocusNotification";
 NSNotificationName const EditorViewDidSaveNotification        = @"EditorViewDidSaveNotification";
 NSNotificationName const EditorViewDidScrollNotification = @"EditorViewDidScrollNotification";
+NSNotificationName const EditorViewZoomDidChangeNotification  = @"EditorViewZoomDidChangeNotification";
 
 // Forward-declare Lexilla's CreateLexer (statically linked)
 namespace Scintilla { struct ILexer5; }
@@ -1254,6 +1255,16 @@ static NSUInteger nppLargeFileThreshold(void) {
 
 - (NSInteger)lineCount {
     return [_scintillaView message:SCI_GETLINECOUNT];
+}
+#pragma mark - Zoom Info
+
+- (NSInteger)zoomLevel {
+    return [_scintillaView message:SCI_GETZOOM wParam:0 lParam:0];
+}
+
+- (NSInteger)zoomPercentage {
+    NSInteger zoom = self.zoomLevel;
+    return 100 + zoom * 10;
 }
 
 - (BOOL)hasBOM { return _hasBOM; }
@@ -4751,6 +4762,9 @@ static NSSet<NSString *> *_cLikeLanguages() {
             // from inside SCI_SETZOOM / SCI_ZOOMIN / SCI_ZOOMOUT, covering
             // every zoom path (menu, Ctrl+scroll, plugin SCI_SETZOOM).
             [self recomputeLineNumberMargin];
+            [[NSNotificationCenter defaultCenter]
+                postNotificationName:EditorViewZoomDidChangeNotification
+                              object:self];
             break;
         default:
             break;

--- a/src/MainWindowController.mm
+++ b/src/MainWindowController.mm
@@ -2116,6 +2116,9 @@ static void _nppTahoeRoundEditorCard(NSView *container, NSView *content) {
             addObserver:self selector:@selector(_editorDidSave:)
                    name:EditorViewDidSaveNotification object:nil];
         [[NSNotificationCenter defaultCenter]
+            addObserver:self selector:@selector(_editorZoomDidChange:)
+                   name:EditorViewZoomDidChangeNotification object:nil];
+        [[NSNotificationCenter defaultCenter]
             addObserver:self selector:@selector(_shortcutsChanged:)
                    name:NPPShortcutsChangedNotification object:nil];
         // (scroll sync uses a timer, not notifications)
@@ -7550,6 +7553,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     NSInteger zoom = [ed.scintillaView message:SCI_GETZOOM];
     [[NSUserDefaults standardUserDefaults] setInteger:zoom forKey:kPrefZoomLevel];
     [self _propagateEditorZoom:zoom];
+    [self updateStatusBar];
 }
 
 - (void)zoomOut:(id)sender {
@@ -7561,6 +7565,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     NSInteger zoom = [ed.scintillaView message:SCI_GETZOOM];
     [[NSUserDefaults standardUserDefaults] setInteger:zoom forKey:kPrefZoomLevel];
     [self _propagateEditorZoom:zoom];
+    [self updateStatusBar];
 }
 
 - (void)resetZoom:(id)sender {
@@ -7571,6 +7576,7 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     [ed.scintillaView message:SCI_SETZOOM wParam:0];
     [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:kPrefZoomLevel];
     [self _propagateEditorZoom:0];
+    [self updateStatusBar];
 }
 
 - (void)toggleShowAllChars:(id)sender {
@@ -8355,6 +8361,15 @@ static NSArray<NSDictionary *> *convertRecordedToXmlFormat(NSArray<NSDictionary 
     if (ed == [self currentEditor]) {
         [self updateStatusBar];
         [self refreshCurrentTab];
+    }
+}
+
+- (void)_editorZoomDidChange:(NSNotification *)note {
+    EditorView *ed = note.object;
+    if (ed == [self currentEditor]) {
+        NSInteger zoom = ed.zoomLevel;
+        [[NSUserDefaults standardUserDefaults] setInteger:zoom forKey:kPrefZoomLevel];
+        [self updateStatusBar];
     }
 }
 
@@ -11039,8 +11054,8 @@ static NSString *languageDisplayName(NSString *langCode) {
     EditorView *ed = [self currentEditor];
     if (!ed) { _statusLeft.stringValue = _statusRight.stringValue = @""; return; }
     sptr_t docLength = [ed.scintillaView message:SCI_GETLENGTH wParam:0 lParam:0];
-    _statusLeft.stringValue  = [NSString stringWithFormat:@"Ln %ld, Col %ld  |  Length: %ld  |  Lines: %ld",
-                                 (long)ed.cursorLine, (long)ed.cursorColumn, (long)docLength, (long)ed.lineCount];
+    _statusLeft.stringValue  = [NSString stringWithFormat:@"Ln %ld, Col %ld  |  Length: %ld  |  Lines: %ld  |  Zoom: %ld%%",
+                                 (long)ed.cursorLine, (long)ed.cursorColumn, (long)docLength, (long)ed.lineCount, (long)ed.zoomPercentage];
     NSString *lang = languageDisplayName(ed.currentLanguage);
     NSString *mode = ed.isOverwriteMode ? @"OVR" : @"INS";
     _statusRight.stringValue = [NSString stringWithFormat:@"%@  |  %@  |  %@  |  %@",
@@ -11053,7 +11068,32 @@ static NSString *languageDisplayName(NSString *langCode) {
 // ignored — and nothing about the status bar's appearance changes.
 - (void)_statusBarDoubleClicked:(NSClickGestureRecognizer *)gr {
     EditorView *ed = [self currentEditor];
-    if (!ed || !_statusRight.stringValue.length) return;
+    if (!ed) return;
+
+    const NSPoint p = [gr locationInView:_statusBar];
+    const CGFloat pad = 6.0;                          // forgiving hit area
+
+    // ── Zoom token double-click (Notepad++ parity) ──
+    // Double-clicking the "Zoom: X%" segment on the left status bar resets the
+    // editor zoom back to default 100% (SCI_SETZOOM 0), matching Notepad++ Windows.
+    if (_statusLeft.stringValue.length) {
+        NSString *leftFull = _statusLeft.stringValue;
+        NSRange zoomRange = [leftFull rangeOfString:@"Zoom:"];
+        if (zoomRange.location != NSNotFound) {
+            NSDictionary *attrs = @{ NSFontAttributeName: _statusLeft.font };
+            NSString *preZoom = [leftFull substringToIndex:zoomRange.location];
+            CGFloat preW = [preZoom sizeWithAttributes:attrs].width;
+            CGFloat zoomW = [[leftFull substringFromIndex:zoomRange.location] sizeWithAttributes:attrs].width;
+            const NSRect leftFr = _statusLeft.frame;
+            const CGFloat zoomLeft = NSMinX(leftFr) + preW;
+            if (p.x >= zoomLeft - pad && p.x <= zoomLeft + zoomW + pad) {
+                [self resetZoom:nil];
+                return;
+            }
+        }
+    }
+
+    if (!_statusRight.stringValue.length) return;
 
     // Compute the language token's x-range inside the right-aligned label by
     // measuring text widths with the field's own font. The text hugs the field's
@@ -11066,8 +11106,6 @@ static NSString *languageDisplayName(NSString *langCode) {
     const NSRect fr = _statusRight.frame;            // already in _statusBar coords
     const CGFloat textLeft = NSMaxX(fr) - wFull;
 
-    const NSPoint p = [gr locationInView:_statusBar];
-    const CGFloat pad = 6.0;                          // forgiving hit area
     if (p.x < textLeft - pad || p.x > textLeft + wLang + pad) return;
 
     // Pop up the LIVE menu-bar Language submenu (locale-stable tag) so its


### PR DESCRIPTION
### What this does
Adds a live Zoom indicator (`Zoom: 100%`) to the status bar that automatically updates whenever the editor zoom changes through any pathway (Ctrl + mouse wheel scroll, keyboard shortcuts `⌘+`/`⌘-`/`⌘0`, trackpad pinch, menu items, or plugins). Double-clicking the `Zoom: X%` segment on the status bar resets the zoom level back to default 100%, matching Notepad++ on Windows.

---


### Changes

* **EditorView.h**
  * Declared `EditorViewZoomDidChangeNotification`.
  * Added `zoomLevel` (`NSInteger`, Scintilla point delta via `SCI_GETZOOM`) and `zoomPercentage` (`NSInteger`, mapped percentage `100 + zoom * 10`) readonly properties.

* **EditorView.mm**
  * Defined `EditorViewZoomDidChangeNotification`.
  * Implemented `zoomLevel` and `zoomPercentage` property getters under `#pragma mark - Zoom Info`.
  * Updated the `case SCN_ZOOM:` notification handler to post `EditorViewZoomDidChangeNotification` across `NSNotificationCenter` whenever Scintilla completes a zoom step.

* **MainWindowController.mm**
  * Registered `_editorZoomDidChange:` observer for `EditorViewZoomDidChangeNotification` in `initWithWindow:`.
  * Implemented `_editorZoomDidChange:` to synchronize the active zoom level with `kPrefZoomLevel` in `NSUserDefaults` and trigger `updateStatusBar`.
  * Added explicit `[self updateStatusBar]` calls in `zoomIn:`, `zoomOut:`, and `resetZoom:` for immediate UI feedback.
  * Updated `updateStatusBar` to append `Zoom: %ld%%` using `ed.zoomPercentage` to the left status bar label (`_statusLeft`).
  * Updated `_statusBarDoubleClicked:` with hit testing on `_statusLeft`'s `"Zoom:"` substring to invoke `[self resetZoom:nil]` when double-clicked.

---

### Testing
* Builds clean in Debug and Release as universal binaries (`arm64;x86_64`), verified with `lipo -info`.
* Tested zooming with Ctrl + mouse wheel, keyboard shortcuts (`⌘+`, `⌘-`, `⌘0`), and menu items — status bar updates immediately.
* Tested double-clicking the `Zoom: X%` text in the status bar — resets zoom to 100%.

<img width="1708" height="981" alt="image" src="https://github.com/user-attachments/assets/36653ad6-3db9-4c34-b86c-30f77f659a2f" />
<img width="1709" height="981" alt="image" src="https://github.com/user-attachments/assets/f8b9a648-bd36-4339-9f7d-c0198fa24677" />
