### PR TITLE
Keep reassigned rectangular-selection shortcuts from collapsing the block (#266)

### DIFF
--- a/scintilla/cocoa/ScintillaCocoa.h
+++ b/scintilla/cocoa/ScintillaCocoa.h
@@ -222,6 +222,10 @@ public:
 	void SetDocPointer(Document *document) override;
 
 	bool KeyboardInput(NSEvent *event);
+	/// The keymap command this event would run, or Message(0) for none. Answers the
+	/// same question KeyboardInput does and applies the same skips, so a caller can
+	/// look ahead at a key without executing it.
+	Scintilla::Message CommandForKeyEvent(NSEvent *event);
 	void MouseDown(NSEvent *event);
 	void MarginMouseDown(NSEvent *event, NSView *marginView);
 	void RightMouseDown(NSEvent *event);

--- a/scintilla/cocoa/ScintillaCocoa.mm
+++ b/scintilla/cocoa/ScintillaCocoa.mm
@@ -2282,6 +2282,50 @@ static KeyMod TranslateModifierFlags(NSUInteger modifiers) {
  * @param event The event instance associated with the key down event.
  * @return True if the input was handled, false otherwise.
  */
+/**
+ * Decide whether one UTF-16 unit of an event's charactersIgnoringModifiers should be
+ * offered to the command keymap, and if so what key and modifiers to look it up with.
+ * Shared by KeyboardInput and CommandForKeyEvent so the two cannot drift apart: a
+ * caller that looks ahead at a key must apply exactly the skips that decide whether
+ * the command runs.
+ */
+static bool ScintillaCommandKey(UniChar originalKey, NSEventModifierFlags modifierFlags,
+				Keys &key, KeyMod &modifiers) {
+	// Some Unicode extended Latin characters overlap the Keys enumeration so treat them
+	// only as and not as command keys.
+	if (originalKey >= static_cast<UniChar>(Keys::Down) && originalKey <= static_cast<UniChar>(Keys::Menu))
+		return false;
+
+	key = KeyTranslate(originalKey, modifierFlags);
+
+	// Let AppKit's interpretKeyEvents dispatch the standard macOS
+	// text-edit shortcuts via NSResponder selectors instead of
+	// firing Scintilla's own command (which is keyed off Windows
+	// conventions). Cmd→Ctrl and Option→Alt translation in
+	// TranslateModifierFlags below would otherwise route:
+	//   Cmd+Backspace     → Ctrl+Back  → DelWordLeft  (wrong; want DelLineLeft)
+	//   Option+Backspace  → Alt+Back   → DelWordLeft  (right action, but route via selector for consistency / System Settings)
+	//   Option+Delete fwd → Alt+Delete → (no entry, falls through)
+	// Short-circuit only the three combos that AppKit binds to a
+	// matching selector. Cmd+Delete fwd is NOT bound by AppKit, so
+	// it stays in Scintilla's keymap (fixed there separately).
+	const NSEventModifierFlags allMods =
+		NSEventModifierFlagCommand | NSEventModifierFlagOption |
+		NSEventModifierFlagShift   | NSEventModifierFlagControl;
+	const NSEventModifierFlags onlyMods = modifierFlags & allMods;
+	const bool cmdOnly    = (onlyMods == NSEventModifierFlagCommand);
+	const bool optionOnly = (onlyMods == NSEventModifierFlagOption);
+	if ((key == Keys::Back   && (cmdOnly || optionOnly)) ||
+	    (key == Keys::Delete &&  optionOnly)) {
+		return false;
+	}
+
+	modifiers = TranslateModifierFlags(modifierFlags);
+	return true;
+}
+
+//--------------------------------------------------------------------------------------------------
+
 bool ScintillaCocoa::KeyboardInput(NSEvent *event) {
 	// For now filter out function keys.
 	NSString *input = event.charactersIgnoringModifiers;
@@ -2290,46 +2334,43 @@ bool ScintillaCocoa::KeyboardInput(NSEvent *event) {
 
 	// Handle each entry individually. Usually we only have one entry anyway.
 	for (size_t i = 0; i < input.length; i++) {
-		const UniChar originalKey = [input characterAtIndex: i];
-		// Some Unicode extended Latin characters overlap the Keys enumeration so treat them
-		// only as and not as command keys.
-		if (originalKey >= static_cast<UniChar>(Keys::Down) && originalKey <= static_cast<UniChar>(Keys::Menu))
+		Keys key = static_cast<Keys>(0);
+		KeyMod modifiers = KeyMod::Norm;
+		if (!ScintillaCommandKey([input characterAtIndex: i], event.modifierFlags, key, modifiers))
 			continue;
-		NSEventModifierFlags modifierFlags = event.modifierFlags;
-
-		Keys key = KeyTranslate(originalKey, modifierFlags);
-
-		// Let AppKit's interpretKeyEvents dispatch the standard macOS
-		// text-edit shortcuts via NSResponder selectors instead of
-		// firing Scintilla's own command (which is keyed off Windows
-		// conventions). Cmd→Ctrl and Option→Alt translation in
-		// TranslateModifierFlags below would otherwise route:
-		//   Cmd+Backspace     → Ctrl+Back  → DelWordLeft  (wrong; want DelLineLeft)
-		//   Option+Backspace  → Alt+Back   → DelWordLeft  (right action, but route via selector for consistency / System Settings)
-		//   Option+Delete fwd → Alt+Delete → (no entry, falls through)
-		// Short-circuit only the three combos that AppKit binds to a
-		// matching selector. Cmd+Delete fwd is NOT bound by AppKit, so
-		// it stays in Scintilla's keymap (fixed there separately).
-		const NSEventModifierFlags allMods =
-			NSEventModifierFlagCommand | NSEventModifierFlagOption |
-			NSEventModifierFlagShift   | NSEventModifierFlagControl;
-		const NSEventModifierFlags onlyMods = modifierFlags & allMods;
-		const bool cmdOnly    = (onlyMods == NSEventModifierFlagCommand);
-		const bool optionOnly = (onlyMods == NSEventModifierFlagOption);
-		if ((key == Keys::Back   && (cmdOnly || optionOnly)) ||
-		    (key == Keys::Delete &&  optionOnly)) {
-			continue;
-		}
 
 		bool consumed = false; // Consumed as command?
 
-		if (KeyDownWithModifiers(key, TranslateModifierFlags(modifierFlags), &consumed))
+		if (KeyDownWithModifiers(key, modifiers, &consumed))
 			handled = true;
 		if (consumed)
 			handled = true;
 	}
 
 	return handled;
+}
+
+//--------------------------------------------------------------------------------------------------
+
+/**
+ * The command KeyboardInput would run for this event, or Message(0) when it would run
+ * none — including the combinations KeyboardInput deliberately hands to AppKit, which
+ * a raw kmap.Find would wrongly report as commands.
+ */
+Message ScintillaCocoa::CommandForKeyEvent(NSEvent *event) {
+	NSString *input = event.charactersIgnoringModifiers;
+
+	for (size_t i = 0; i < input.length; i++) {
+		Keys key = static_cast<Keys>(0);
+		KeyMod modifiers = KeyMod::Norm;
+		if (!ScintillaCommandKey([input characterAtIndex: i], event.modifierFlags, key, modifiers))
+			continue;
+		const Message msg = kmap.Find(key, modifiers);
+		if (msg != static_cast<Message>(0))
+			return msg;
+	}
+
+	return static_cast<Message>(0);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/scintilla/cocoa/ScintillaView.mm
+++ b/scintilla/cocoa/ScintillaView.mm
@@ -795,6 +795,26 @@ static NSCursor *cursorFromEnum(Window::Cursor cursor) {
 			return; // not a key that should collapse the column selection
 	}
 
+	// A rectangular-extend command must never collapse the block it is extending,
+	// whatever key it happens to be bound to. The Option test above covers only the
+	// stock Opt+Shift+arrow bindings; a shortcut reassigned in the Shortcut Mapper
+	// carries no Option, so without this the selection collapsed on every press and
+	// the block could never grow past two lines.
+	switch (mOwner.backend->CommandForKeyEvent(theEvent)) {
+		case Message::LineDownRectExtend:
+		case Message::LineUpRectExtend:
+		case Message::CharLeftRectExtend:
+		case Message::CharRightRectExtend:
+		case Message::HomeRectExtend:
+		case Message::VCHomeRectExtend:
+		case Message::LineEndRectExtend:
+		case Message::PageUpRectExtend:
+		case Message::PageDownRectExtend:
+			return;
+		default:
+			break;
+	}
+
 	// Switch to stream mode so the key acts on independent carets. The second
 	// call clears the lingering rectangular anchor so subsequent caret movement
 	// stays multi-caret (Neil Hodgson, https://sourceforge.net/p/scintilla/bugs/2412/).


### PR DESCRIPTION
Fixes #266.

Reassign `SCI_LINEDOWNRECTEXTEND` and friends to any shortcut that does not include Option, and the column block stops growing: it reaches two lines and then just walks down the file, and widening an existing block collapses it to one line.

### Cause

`convertColumnSelectionToMultiEditForKey` implements the "Column selection switches to multi-editing" preference by turning a rectangular selection into a stream multi-selection when an arrow, Home, End, Backspace or Return arrives. It skips that conversion only while Option is held, because the stock rect-extend bindings are `Opt+Shift+arrow`. A shortcut assigned in the Shortcut Mapper carries no Option, so the conversion collapses the very selection the command is extending, on every press.

### Fix

Gate the conversion on what the key actually resolves to: if the keymap would run one of the nine `SCI_*RECTEXTEND` commands, leave the rectangular selection alone whatever modifiers the key carries. The Option test is kept, so the change only ever **adds** cases where the conversion is skipped.

The lookup goes through a new `ScintillaCocoa::CommandForKeyEvent` that shares its decision path with `KeyboardInput`, extracted here as `ScintillaCommandKey`. That sharing matters: `KeyboardInput` deliberately hands `Cmd+Backspace`, `Option+Backspace` and `Option+ForwardDelete` to AppKit after translating them, so a raw `kmap.Find` would report a command for events that never run one, and the guard would then suppress the conversion for a key that does something else entirely.

### Verification

On a build of `main`, driving keys into a 60-line file and copying the selection back out:

| case | before | after |
|---|---|---|
| reassigned `Cmd+Shift+arrows`, 8× right then 4× down | 2 lines | 8 columns × 5 lines |
| stock `Opt+Shift+arrows`, same sequence | 8 × 5 | 8 × 5 |
| rectangular block, then plain `Down`, then a character typed | one character on three lines | identical |

The third case is the control for the guard itself: the multi-editing conversion this preference exists for still fires.
