### PR TITLE
Show the real macOS defaults in the Shortcut Mapper's Scintilla tab

### DIFF
--- a/src/EditorView.h
+++ b/src/EditorView.h
@@ -404,3 +404,15 @@ extern NSNotificationName const EditorViewZoomDidChangeNotification;
 @end
 
 NS_ASSUME_NONNULL_END
+
+/// Default macOS key bindings for a Scintilla command, read from the same generated
+/// table the editor installs (kSciDefaultKeys in EditorView.mm — built from
+/// scintilla/src/KeyMap.cxx MapDefault plus the scintilla/cocoa/ScintillaCocoa.mm
+/// macMapDefault overlay). Writes up to maxCombos key definitions
+/// (keyDef = sckKey | (mod << 16)) into combos and returns how many it WROTE, so the
+/// count is always safe as a loop bound. 0 means the command has no default binding
+/// on macOS — every command with one is present in the table.
+///
+/// Exposed so the Shortcut Mapper can show what the editor really does rather than
+/// keeping a second, hand-maintained copy of the defaults that can drift from it.
+int NppScintillaDefaultKeyCombos(int sciID, int *combos, int maxCombos);

--- a/src/EditorView.mm
+++ b/src/EditorView.mm
@@ -2273,6 +2273,17 @@ static const struct SciDefaultKeys *sciDefaultKeysFor(int sciID) {
     return NULL;
 }
 
+// Declared in EditorView.h — lets the Shortcut Mapper read the real defaults instead of
+// carrying its own copy. Keeps the table private; only the combos leave this file.
+int NppScintillaDefaultKeyCombos(int sciID, int *combos, int maxCombos) {
+    const struct SciDefaultKeys *d = sciDefaultKeysFor(sciID);
+    if (!d) return 0;
+    int n = (d->n < maxCombos) ? d->n : maxCombos;   // return what was WRITTEN, so a
+    for (int i = 0; i < n; i++)                      // caller can use it as a loop bound
+        combos[i] = (int)d->combos[i];
+    return n;
+}
+
 // Push the user's Scintilla-command shortcut overrides (from ~/Library/Application Support/Nextpad++/shortcuts.xml)
 // into this editor's Scintilla keymap. Called once at construction and live on every
 // NPPShortcutsChangedNotification (via MainWindowController). Authoritative-per-command:

--- a/src/ShortcutMapperWindowController.mm
+++ b/src/ShortcutMapperWindowController.mm
@@ -3,6 +3,7 @@
 #import "AppDelegate.h"
 #import "MainWindowController.h"
 #import "MenuBuilder.h"          // kMenuTagPlugins
+#import "EditorView.h"           // NppScintillaDefaultKeyCombos
 #import "NppPluginManager.h"
 #import "NppLocalizer.h"
 
@@ -604,6 +605,46 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
     NSLog(@"[ShortcutMapper] Plugin commands: %lu entries", (unsigned long)_pluginEntries.count);
 }
 
+/// Inverse of EditorView.mm's vkToScintillaKey(): turns a Scintilla key code back into
+/// the Windows-style VK code a ShortcutEntry stores. Returns 0 for keys this window has
+/// no vocabulary for — Scintilla puts zoom on the numeric-keypad +, - and /, which
+/// keyNameForCode: cannot render and the key popup cannot offer.
+static NSUInteger sciKeyToVKCode(int sck) {
+    switch (sck) {
+        case 8:    return 8;    // Backspace
+        case 9:    return 9;    // Tab
+        case 13:   return 13;   // Enter
+        case 7:    return 27;   // SCK_ESCAPE
+        case 306:  return 33;   // Page Up
+        case 307:  return 34;   // Page Down
+        case 305:  return 35;   // End
+        case 304:  return 36;   // Home
+        case 302:  return 37;   // Left
+        case 301:  return 38;   // Up
+        case 303:  return 39;   // Right
+        case 300:  return 40;   // Down
+        case 309:  return 45;   // Insert
+        case 308:  return 46;   // Delete
+        case ';':  return 186;
+        case '=':  return 187;
+        case ',':  return 188;
+        case '-':  return 189;
+        case '.':  return 190;
+        case '/':  return 191;
+        case '`':  return 192;
+        case '[':  return 219;
+        case '\\': return 220;
+        case ']':  return 221;
+        case '\'': return 222;
+        default:   break;
+    }
+    if (sck >= 0xF704 && sck <= 0xF70F) return 112 + (sck - 0xF704);  // F1-F12
+    if (sck >= 'a' && sck <= 'z') return sck - 32;   // entries hold upper case
+    if (sck >= 'A' && sck <= 'Z') return sck;
+    if (sck >= '0' && sck <= '9') return sck;
+    return 0;
+}
+
 - (void)_loadScintillaEntries {
     _scintillaEntries = [NSMutableArray array];
     // Hardcoded Scintilla command definitions matching Windows scintKeyDefs[]
@@ -745,11 +786,48 @@ NSNotificationName const NPPShortcutsChangedNotification = @"NPPShortcutsChanged
             e.keyCode  = keyCode;
             e.isModified = YES; // mark so it gets re-saved
         } else {
-            // Map Windows Ctrl to macOS Cmd (defaults)
-            e.hasCmd   = defs[i].ctrl;
-            e.hasAlt   = defs[i].alt;
-            e.hasShift = defs[i].shift;
-            e.keyCode  = defs[i].key;
+            // Defaults come from the editor's real keymap, not from the Windows table
+            // above. ScintillaCocoa lays macMapDefault over the generic MapDefault, which
+            // rebinds a dozen of these commands, so mapping Windows Ctrl to Cmd describes
+            // a keyboard nobody has: it claimed ⌘↓ scrolls a line when ⌘↓ actually runs
+            // SCI_DOCUMENTEND, and listed SCI_HOME on Home when Home runs SCI_VCHOME.
+            //
+            // Prefer the hardcoded combo when it IS one of the real bindings — for a
+            // multi-bound command it is the one a mac user recognises (Cut keeps ⌘X
+            // rather than the equally-real ⇧⌦) — and otherwise show the first real one.
+            int combos[8];
+            int n = NppScintillaDefaultKeyCombos(defs[i].sciID, combos, 8);
+            int chosen = -1;
+            for (int c = 0; c < n; c++) {
+                NSUInteger cvk = sciKeyToVKCode(combos[c] & 0xFFFF);
+                int mod = combos[c] >> 16;
+                // The hardcoded table cannot express Meta, so a match needs it clear.
+                if (cvk != 0 && cvk == (NSUInteger)defs[i].key && (mod & 16) == 0 &&
+                    defs[i].ctrl  == ((mod & 2) != 0) &&
+                    defs[i].alt   == ((mod & 4) != 0) &&
+                    defs[i].shift == ((mod & 1) != 0)) { chosen = combos[c]; break; }
+            }
+            if (chosen < 0 && n > 0) chosen = combos[0];
+
+            NSUInteger vk = (chosen < 0) ? 0 : sciKeyToVKCode(chosen & 0xFFFF);
+            if (vk != 0) {
+                int mod = chosen >> 16;
+                e.hasShift = (mod & 1)  != 0;   // KeyMod::Shift
+                e.hasCmd   = (mod & 2)  != 0;   // KeyMod::Ctrl — Command on macOS
+                e.hasAlt   = (mod & 4)  != 0;   // KeyMod::Alt  — Option
+                e.hasCtrl  = (mod & 16) != 0;   // KeyMod::Meta — the physical Control key
+                e.keyCode  = vk;
+            } else if (n > 0) {
+                // Bound to a key this window has no name for (zoom lives on the numeric
+                // keypad). Keep the old value rather than blanking a bound command; the
+                // View menu's ⌘+/⌘-/⌘0 are what a mac user presses for these anyway.
+                e.hasCmd   = defs[i].ctrl;
+                e.hasAlt   = defs[i].alt;
+                e.hasShift = defs[i].shift;
+                e.keyCode  = defs[i].key;
+            } else {
+                e.keyCode = 0;   // genuinely unbound on macOS
+            }
         }
         // The 6 standard-edit commands whose Scintilla-tab shortcut sits on the EXACT
         // same key as a Cocoa Edit-menu item (Select All ⌘A, Undo ⌘Z, Redo ⌘⇧Z, Cut ⌘X,


### PR DESCRIPTION
Relates to #267.

The Shortcut Mapper's Scintilla tab took its default shortcuts from a hardcoded copy of the Windows `scintKeyDefs[]` table and displayed them by mapping Windows Ctrl to Cmd. On macOS that describes a keyboard nobody has: `ScintillaCocoa` lays `macMapDefault` over Scintilla's generic `MapDefault` at construction, which rebinds a dozen of these commands.

The result is not cosmetic. The mapper listed `Cmd+Down` for `SCI_LINESCROLLDOWN` while `Cmd+Down` actually runs `SCI_DOCUMENTEND`, and listed `Home` for `SCI_HOME` while `Home` actually runs `SCI_VCHOME`. The conflict checker compares these same displayed values, so it could not see the real collision on `Cmd+Down` either — which is the case where a warning would matter most.

### Fix

The correct data was already in the tree and already in the binary: `kSciDefaultKeys` in `EditorView.mm`, generated from `KeyMap.cxx` `MapDefault` plus the `ScintillaCocoa` `macMapDefault` overlay, and used by `applyScintillaKeyOverrides` to clear and restore defaults. The mapper now reads that table through a new accessor instead of keeping a second copy that can drift from it.

For a command with several default bindings, the hardcoded combo is kept when it is one of the real ones — so Cut still shows `Cmd+X` rather than the equally-real `Shift+Delete` — and otherwise the first real binding is shown.

### Verification

Every row's displayed shortcut was dumped from both builds. 99 rows each, 87 byte-identical, 12 changed:

| command | before | after |
|---|---|---|
| `SCI_LINESCROLLDOWN` | `Cmd+Down` | `Ctrl+Down` |
| `SCI_LINESCROLLUP` | `Cmd+Up` | `Ctrl+Up` |
| `SCI_WORDLEFT` | `Cmd+Left` | `Opt+Left` |
| `SCI_WORDLEFTEXTEND` | `Cmd+Shift+Left` | `Ctrl+Shift+Left` |
| `SCI_WORDRIGHT` | `Cmd+Right` | `Opt+Right` |
| `SCI_WORDRIGHTEXTEND` | `Cmd+Shift+Right` | `Ctrl+Shift+Right` |
| `SCI_HOME` | `Home` | *(none)* |
| `SCI_HOMEEXTEND` | `Shift+Home` | *(none)* |
| `SCI_VCHOME` | *(none)* | `Home` |
| `SCI_VCHOMEEXTEND` | *(none)* | `Shift+Home` |
| `SCI_DELWORDRIGHT` | `Cmd+Del` | *(none)* |
| `SCI_LINECOPY` | `Cmd+Shift+X` | `Cmd+Shift+T` |

`kSciDefaultKeys` itself was checked rather than trusted, since it is the whole basis of the change: a probe constructing a real `Scintilla::Internal::KeyMap` and replaying `ScintillaCocoa::Init()`'s `AssignCmdKey` loop over `macMapDefault` agrees with it on all 68 entries, and no command in the mapper's list has a real binding missing from it. Absence from the table therefore means the command genuinely has no macOS default, which is why three rows now show nothing.

### Scope

Zoom is deliberately left alone. `SCI_ZOOMIN`/`ZOOMOUT`/`SETZOOM` really are bound to Cmd plus the numeric-keypad `+`, `-` and `/`, which the key popup cannot offer and `keyNameForCode:` cannot render, so those three rows keep the View-menu equivalents they showed before. Teaching the picker the keypad keys would be a separate change, and it is your call whether it is wanted.

Two pre-existing limitations are unchanged: only one binding per command is displayed, so a conflict against a command's secondary default is still invisible; and opening Modify on a defaulted command and pressing OK still records an override that reinstalls only the displayed binding.

This changes displayed defaults only — no key dispatch is touched. It does not textually overlap #293, which edits `keyCodeForName:` and the key-name tables.
